### PR TITLE
Prevents JujuMate from crashing when a model is removed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jujumate"
-version = "0.2.0"
+version = "0.2.1"
 description = "Terminal UI for Juju infrastructure orchestration"
 readme = "README.md"
 authors = [

--- a/src/jujumate/client/juju_client.py
+++ b/src/jujumate/client/juju_client.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import Any
 
 import websockets
+import websockets.exceptions
 from juju.client import client as juju_client
 from juju.controller import Controller
 from juju.errors import JujuError
@@ -597,7 +598,10 @@ class JujuClient:
         self, model_name: str
     ) -> tuple[list[RelationInfo], list[OfferInfo], list[SAASInfo]]:
         """Fetch relations, offers and SAAS for a model in a single connection."""
-        model = await self._controller.get_model(model_name)
+        try:
+            model = await self._controller.get_model(model_name)
+        except websockets.exceptions.InvalidStatusCode as exc:
+            raise JujuError(f"Model '{model_name}' is no longer available: {exc}") from exc
         try:
             status = await model.get_status()
             app_statuses = status.applications or {}
@@ -642,7 +646,10 @@ class JujuClient:
     async def get_secrets(self, model_name: str) -> list[SecretInfo]:
         """Fetch all secrets visible in the given model."""
         secrets: list[SecretInfo] = []
-        model = await self._controller.get_model(model_name)
+        try:
+            model = await self._controller.get_model(model_name)
+        except websockets.exceptions.InvalidStatusCode as exc:
+            raise JujuError(f"Model '{model_name}' is no longer available: {exc}") from exc
         try:
             results = await model.list_secrets()
             for s in results or []:
@@ -669,7 +676,10 @@ class JujuClient:
 
     async def get_secret_content(self, model_name: str, secret_uri: str) -> dict[str, str]:
         """Fetch the key-value content of a secret by URI (requires show_secrets=True)."""
-        model = await self._controller.get_model(model_name)
+        try:
+            model = await self._controller.get_model(model_name)
+        except websockets.exceptions.InvalidStatusCode as exc:
+            raise JujuError(f"Model '{model_name}' is no longer available: {exc}") from exc
         try:
             results = await model.list_secrets(show_secrets=True)
             for s in results or []:
@@ -692,7 +702,10 @@ class JujuClient:
     async def get_app_config(self, model_name: str, app_name: str) -> list[AppConfigEntry]:
         """Fetch configuration entries for an application."""
         entries: list[AppConfigEntry] = []
-        model = await self._controller.get_model(model_name)
+        try:
+            model = await self._controller.get_model(model_name)
+        except websockets.exceptions.InvalidStatusCode as exc:
+            raise JujuError(f"Model '{model_name}' is no longer available: {exc}") from exc
         try:
             app = model.applications.get(app_name)
             if not app:
@@ -744,7 +757,10 @@ class JujuClient:
         provider unit we get: provider app-level data + requirer units' data.
         From the requirer unit we get: requirer app-level data + provider units' data.
         """
-        model = await self._controller.get_model(model_name)
+        try:
+            model = await self._controller.get_model(model_name)
+        except websockets.exceptions.InvalidStatusCode as exc:
+            raise JujuError(f"Model '{model_name}' is no longer available: {exc}") from exc
         try:
             facade = juju_client.ApplicationFacade.from_connection(model.connection())
             entries: list[RelationDataEntry] = []
@@ -788,7 +804,7 @@ class JujuClient:
                 if (offer.offer_name or "") != offer_name:
                     continue
                 return _build_controller_offer_info(offer, model_name, status_counts)
-        except JujuError:
+        except (JujuError, websockets.exceptions.InvalidStatusCode):
             logger.warning(
                 "Could not fetch offer detail for '%s' in model '%s'", offer_name, model_name
             )
@@ -810,7 +826,7 @@ class JujuClient:
                     await model.disconnect()
                 for offer in raw.results or []:
                     result.append(_build_controller_offer_info(offer, model_name, status_counts))
-            except JujuError:
+            except (JujuError, websockets.exceptions.InvalidStatusCode):
                 logger.warning("Could not list offers for model '%s'", model_name)
         logger.debug("Controller offers: %d total", len(result))
         return result

--- a/src/jujumate/screens/main_screen.py
+++ b/src/jujumate/screens/main_screen.py
@@ -615,7 +615,13 @@ class MainScreen(Screen):
     async def _open_offer_detail(
         self, controller_name: str, model_name: str, offer_name: str
     ) -> None:
-        async with JujuClient(controller_name=controller_name) as client:
-            detail = await client.get_offer_detail(model_name, offer_name)
+        try:
+            async with JujuClient(controller_name=controller_name) as client:
+                detail = await client.get_offer_detail(model_name, offer_name)
+        except (JujuError, OSError, asyncio.TimeoutError, KeyError):
+            logger.exception(
+                "Failed to fetch offer detail for '%s' in model '%s'", offer_name, model_name
+            )
+            return
         if detail:
             self.app.push_screen(OfferDetailScreen(detail, controller_name))

--- a/tests/test_juju_client.py
+++ b/tests/test_juju_client.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import websockets
+import websockets.exceptions
 from juju.errors import JujuConnectionError, JujuError
 
 from jujumate.client.juju_client import (
@@ -554,6 +555,20 @@ async def test_get_secrets_empty(mock_controller):
     assert result == []
 
 
+@pytest.mark.asyncio
+async def test_get_secrets_raises_juju_error_when_model_gone(mock_controller):
+    # GIVEN the controller raises InvalidStatusCode (model was removed)
+    mock_controller.get_model = AsyncMock(
+        side_effect=websockets.exceptions.InvalidStatusCode(400, None)
+    )
+    client = JujuClient(controller=mock_controller)
+
+    # WHEN get_secrets is called for the removed model
+    # THEN a JujuError is raised instead of crashing
+    with pytest.raises(JujuError, match="no longer available"):
+        await client.get_secrets("removed-model")
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # get_app_config
 # ─────────────────────────────────────────────────────────────────────────────
@@ -634,6 +649,20 @@ async def test_get_app_config_app_not_found(mock_controller):
     result = await client.get_app_config("dev", "missing")
     # THEN an empty list is returned
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_app_config_raises_juju_error_when_model_gone(mock_controller):
+    # GIVEN the controller raises InvalidStatusCode (model was removed)
+    mock_controller.get_model = AsyncMock(
+        side_effect=websockets.exceptions.InvalidStatusCode(400, None)
+    )
+    client = JujuClient(controller=mock_controller)
+
+    # WHEN get_app_config is called for the removed model
+    # THEN a JujuError is raised instead of crashing
+    with pytest.raises(JujuError, match="no longer available"):
+        await client.get_app_config("removed-model", "pg")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -784,6 +813,25 @@ async def test_get_status_details_saas_from_remote_applications(mock_controller)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# get_status_details — model no longer available (InvalidStatusCode)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_status_details_raises_juju_error_when_model_gone(mock_controller):
+    # GIVEN the controller raises InvalidStatusCode (model was removed)
+    mock_controller.get_model = AsyncMock(
+        side_effect=websockets.exceptions.InvalidStatusCode(400, None)
+    )
+    client = JujuClient(controller=mock_controller)
+
+    # WHEN get_status_details is called for the removed model
+    # THEN a JujuError is raised instead of crashing the app
+    with pytest.raises(JujuError, match="no longer available"):
+        await client.get_status_details("removed-model")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # get_relation_data — peer, empty results, error result, unit-level data
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -927,6 +975,20 @@ async def test_get_controller_offers_uses_status_counts(mock_controller):
     info: ControllerOfferInfo = results[0]
     assert info.active_connections == 1
     assert info.total_connections == 1
+
+
+@pytest.mark.asyncio
+async def test_get_relation_data_raises_juju_error_when_model_gone(mock_controller):
+    # GIVEN the controller raises InvalidStatusCode (model was removed)
+    mock_controller.get_model = AsyncMock(
+        side_effect=websockets.exceptions.InvalidStatusCode(400, None)
+    )
+    client = JujuClient(controller=mock_controller)
+
+    # WHEN get_relation_data is called for the removed model
+    # THEN a JujuError is raised instead of crashing
+    with pytest.raises(JujuError, match="no longer available"):
+        await client.get_relation_data("removed-model", 1, "pg", "wp")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1275,6 +1337,20 @@ async def test_get_secret_content_skips_missing_data(mock_controller, secret_val
     assert result == {}
 
 
+@pytest.mark.asyncio
+async def test_get_secret_content_raises_juju_error_when_model_gone(mock_controller):
+    # GIVEN the controller raises InvalidStatusCode (model was removed)
+    mock_controller.get_model = AsyncMock(
+        side_effect=websockets.exceptions.InvalidStatusCode(400, None)
+    )
+    client = JujuClient(controller=mock_controller)
+
+    # WHEN get_secret_content is called for the removed model
+    # THEN a JujuError is raised instead of crashing
+    with pytest.raises(JujuError, match="no longer available"):
+        await client.get_secret_content("removed-model", "secret:abc123")
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # get_saas
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1361,6 +1437,23 @@ async def test_get_offer_detail_returns_none_on_juju_error(mock_controller):
     assert result is None
 
 
+@pytest.mark.asyncio
+async def test_get_offer_detail_returns_none_when_model_gone(mock_controller):
+    # GIVEN list_offers succeeds but get_model raises InvalidStatusCode
+    raw = MagicMock()
+    raw.results = []
+    mock_controller.list_offers = AsyncMock(return_value=raw)
+    mock_controller.get_model = AsyncMock(
+        side_effect=websockets.exceptions.InvalidStatusCode(400, None)
+    )
+    client = JujuClient(controller=mock_controller)
+
+    # WHEN get_offer_detail is called for the removed model
+    # THEN None is returned instead of crashing
+    result = await client.get_offer_detail("removed-model", "pg-offer")
+    assert result is None
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # get_controller_offers — JujuError per-model fallback
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1395,6 +1488,42 @@ async def test_get_controller_offers_skips_model_on_juju_error(mock_controller):
     client = JujuClient(controller=mock_controller)
     results = await client.get_controller_offers()
     # THEN the broken model is skipped and the ok model's offer is returned
+    assert len(results) == 1
+    assert results[0].name == "pg-offer"
+
+
+@pytest.mark.asyncio
+async def test_get_controller_offers_skips_model_when_model_gone(mock_controller):
+    # GIVEN two models where the first raises InvalidStatusCode on get_model
+    mock_controller.list_models = AsyncMock(return_value=["gone", "ok"])
+    ep = MagicMock()
+    ep.name = "db"
+    ep.interface = "pgsql"
+    ep.role = "provider"
+    offer = MagicMock()
+    offer.offer_name = "pg-offer"
+    offer.offer_url = "admin/ok.pg-offer"
+    offer.application_name = "postgresql"
+    offer.charm_url = "ch:postgresql"
+    offer.application_description = ""
+    offer.endpoints = [ep]
+    offer.users = []
+    raw = MagicMock()
+    raw.results = [offer]
+    mock_controller.list_offers = AsyncMock(return_value=raw)
+    status = MagicMock()
+    status.offers = {}
+    ok_model = AsyncMock()
+    ok_model.get_status = AsyncMock(return_value=status)
+    ok_model.disconnect = AsyncMock()
+    mock_controller.get_model = AsyncMock(
+        side_effect=[websockets.exceptions.InvalidStatusCode(400, None), ok_model]
+    )
+    client = JujuClient(controller=mock_controller)
+
+    # WHEN get_controller_offers is called
+    # THEN the gone model is skipped and the ok model's offer is returned
+    results = await client.get_controller_offers()
     assert len(results) == 1
     assert results[0].name == "pg-offer"
 

--- a/tests/test_main_screen.py
+++ b/tests/test_main_screen.py
@@ -832,9 +832,23 @@ async def test_status_view_offer_selected_calls_open_offer_detail(pilot):
     mock_open.assert_called_once_with("ctrl", offer.model, offer.name)
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Early-return guards: no selection
-# ─────────────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_open_offer_detail_logs_and_returns_on_connection_error(pilot):
+    # GIVEN get_offer_detail raises JujuError (model gone / connection error)
+    screen = pilot.app.screen
+    with patch("jujumate.screens.main_screen.JujuClient") as MockClient:
+        instance = AsyncMock()
+        instance.get_offer_detail = AsyncMock(side_effect=JujuError("gone"))
+        MockClient.return_value.__aenter__ = AsyncMock(return_value=instance)
+        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        # WHEN _open_offer_detail is called
+        screen._open_offer_detail("ctrl", "dev", "pg-offer")
+        for _ in range(10):
+            await pilot.pause()
+
+    # THEN no screen is pushed (method returns gracefully)
+    assert pilot.app.screen is screen
 
 
 def _call_app_selected_no_ctrl(screen) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -711,7 +711,7 @@ wheels = [
 
 [[package]]
 name = "jujumate"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "juju" },


### PR DESCRIPTION
This PR fixes #18


When a Juju model was removed while the app was running, JujuMate crashed with Textual's full error screen showing the traceback.

**Root cause:** `python-libjuju` raises `websockets.exceptions.InvalidStatusCode(400)` when trying to connect to a model that no longer exists. This exception was not caught by the existing handlers (which only caught `JujuError`, `OSError`, `TimeoutError` and `KeyError`), so it escaped the asyncio worker and brought down the app.

**Scope:** the issue affected 7 places in the code — `get_secrets`, `get_secret_content`, `get_app_config`, `get_relation_data`, `get_offer_detail`, `get_controller_offers` (in juju_client.py) and `_open_offer_detail` (in main_screen.py).

**Fix:** for each exposed `get_model()` call, wrap it in a `try/except` that converts `InvalidStatusCode` → `JujuError`, which is already correctly handled by all callers. In `_open_offer_detail` (which had no error handling at all) a full `try/except` was added following the same pattern as the other workers.