### PR TITLE
feat: show unit leadership with colored * marker in Status tab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jujumate"
-version = "0.2.5"
+version = "0.2.6"
 
 description = "Terminal UI for Juju infrastructure orchestration"
 readme = "README.md"

--- a/src/jujumate/client/juju_client.py
+++ b/src/jujumate/client/juju_client.py
@@ -137,6 +137,7 @@ def _parse_unit_info(
         public_address=_s(unit_st.public_address),
         ports=ports_str,
         message=_s(unit_st.workload_status.info) if unit_st.workload_status else "",
+        is_leader=bool(unit_st.leader),
         controller=controller_name,
     )
 

--- a/src/jujumate/models/entities.py
+++ b/src/jujumate/models/entities.py
@@ -145,6 +145,7 @@ class UnitInfo:
     public_address: str = ""
     ports: str = ""
     message: str = ""
+    is_leader: bool = False
     subordinate_of: str = ""  # principal unit name, empty if this is a principal
     model: str = ""
     controller: str = ""

--- a/src/jujumate/widgets/status_view.py
+++ b/src/jujumate/widgets/status_view.py
@@ -38,6 +38,19 @@ def _colored_ip(address: str) -> Text:
     return Text(address)
 
 
+def _unit_name_text(u: UnitInfo, tree_prefix: str, filter_text: str) -> Text:
+    """Build the Rich Text for a unit's name cell, with tree prefix and leader marker."""
+    if tree_prefix:
+        name = Text()
+        name.append(tree_prefix, style=palette.MUTED)
+        name.append_text(_highlight(u.name, filter_text))
+    else:
+        name = _highlight(u.name, filter_text)
+    if u.is_leader:
+        name.append("*", style=palette.SUCCESS)
+    return name
+
+
 def _colored_relation(endpoint: str) -> Text:
     """Color the :rel_name part of an APP:REL endpoint."""
     if ":" in endpoint:
@@ -431,12 +444,7 @@ class StatusView(Widget):
         if self._is_kubernetes:
             table.reset_columns(_UNIT_COLUMNS_K8S)
             for u, tree_prefix in ordered:
-                if tree_prefix:
-                    name = Text()
-                    name.append(tree_prefix, style=palette.MUTED)
-                    name.append_text(_highlight(u.name, self._filter))
-                else:
-                    name = _highlight(u.name, self._filter)
+                name = _unit_name_text(u, tree_prefix, self._filter)
                 rows.append(
                     (
                         name,
@@ -451,12 +459,7 @@ class StatusView(Widget):
         else:
             table.reset_columns(_UNIT_COLUMNS_IAAS)
             for u, tree_prefix in ordered:
-                if tree_prefix:
-                    name = Text()
-                    name.append(tree_prefix, style=palette.MUTED)
-                    name.append_text(_highlight(u.name, self._filter))
-                else:
-                    name = _highlight(u.name, self._filter)
+                name = _unit_name_text(u, tree_prefix, self._filter)
                 machine = "" if u.subordinate_of else u.machine
                 rows.append(
                     (
@@ -544,9 +547,7 @@ class StatusView(Widget):
                     full_msgs.append(item.message)
                     displayed_machines.append(item)
                 else:
-                    name = Text()
-                    name.append(prefix, style=palette.MUTED)
-                    name.append_text(_highlight(item.name, self._filter))
+                    name = _unit_name_text(item, prefix, self._filter)
                     rows.append(
                         (
                             name,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -53,6 +53,7 @@ from jujumate.widgets.status_view import (
     _group_units_by_machine,
     _TrackedScroll,
     _trunc_msg,
+    _unit_name_text,
 )
 from jujumate.widgets.units_view import UnitsView
 
@@ -320,6 +321,40 @@ async def test_status_view_update_units_with_subordinate_prefix(pilot, is_kubern
     # THEN two rows are rendered in the units table
     table = view.query_one("#status-units-table", ResourceTable)
     assert table.query_one("DataTable").row_count == 2
+
+
+def test_unit_name_text_leader_appends_star():
+    # GIVEN a leader unit
+    unit = UnitInfo("pg/0", "pg", "0", "active", "idle", is_leader=True)
+
+    # WHEN _unit_name_text is called
+    name = _unit_name_text(unit, "", "")
+
+    # THEN the rendered plain text ends with '*'
+    assert name.plain.endswith("*"), f"Expected '*' suffix, got: {name.plain!r}"
+
+
+def test_unit_name_text_non_leader_has_no_star():
+    # GIVEN a non-leader unit
+    unit = UnitInfo("pg/1", "pg", "0", "active", "idle", is_leader=False)
+
+    # WHEN _unit_name_text is called
+    name = _unit_name_text(unit, "", "")
+
+    # THEN the rendered text does not contain '*'
+    assert "*" not in name.plain
+
+
+def test_unit_name_text_leader_with_tree_prefix():
+    # GIVEN a leader subordinate unit with a tree prefix
+    unit = UnitInfo("nrpe/0", "nrpe", "0", "active", "idle", is_leader=True, subordinate_of="pg/0")
+
+    # WHEN _unit_name_text is called with a prefix
+    name = _unit_name_text(unit, "└─ ", "")
+
+    # THEN the text contains both the prefix and the '*' suffix
+    assert "└─ " in name.plain
+    assert name.plain.endswith("*")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
 ## What's Changed
 
 Displays which unit is the Juju leader directly in the Status tab,
 following the same convention as `juju status`.
 
 ### Changes
 - Leader units now show a `*` suffix (colored with the theme's success
   color) next to the unit name: `mysql/0*`
 - No extra API calls — leadership is read from the `leader` field
   already present in the `FullStatus` response
 - Marker is rendered in all three unit table contexts: K8s units,
   IaaS units, and the combined Machine+Units view
 - Added `is_leader: bool` field to `UnitInfo`
 - Extracted `_unit_name_text()` helper in `status_view.py` (DRY)