### PR TITLE
feat: collapsible status panels and UX polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
 - 🔎 **Inline filtering** — press `/` in Status or Logs to search with live highlight
 - 🔗 **Peer relation toggle** — press `p` to show/hide peer relations in the Integrations panel
 - 🖥️ **Units-per-machine toggle** — press `u` to show units (and their subordinates) nested under each machine
+- 🗂️ **Collapsible panels** — press `x` to collapse/expand any Status panel individually; focused panel highlighted in theme colour
+- 👑 **Leader indicators** — unit leaders marked with `*` (green) following `juju status` convention
+- 🔗 **Relation lifecycle** — Integrations panel shows live relation status; relations being torn down display as `removing`
 - 📋 **Copy to clipboard** — press `y` in Status or Relation Data to copy the full content
 - 🔐 **Secrets browser** — list and inspect Juju secrets per model (`Shift+S`)
 - 📦 **Offers browser** — browse all cross-model offers in a controller, with endpoint details and live consumer tracking across controllers (`Shift+O`)
@@ -93,6 +96,7 @@ On first launch JujuMate connects to your current Juju controller and auto-selec
 | `Esc` | Clear filter |
 | `p` | Toggle peer relations in the Integrations panel |
 | `u` | Toggle units (and subordinates) nested under each machine |
+| `x` | Collapse/expand the current panel |
 | `y` | Copy full status to clipboard (includes cloud, controller, model and Juju version) |
 | `Enter` on app | Open App Config viewer |
 | `Enter` on offer | Open Offer detail |
@@ -124,7 +128,7 @@ On first launch JujuMate connects to your current Juju controller and auto-selec
 ### Status
 The main view. Displays a full `juju status`-style breakdown of the selected model:
 - **Applications** — name, charm, channel, revision, units, status and workload message
-- **Units** — workload/agent status, machine or pod, address, ports; subordinates shown nested under their principal
+- **Units** — workload/agent status, machine or pod, address, ports; subordinates shown nested under their principal; leader units are marked with `*`
 - **Machines** — id, state, address, instance, base, AZ *(IaaS models only)*; press `u` to expand units and their subordinates inline; press `Enter` on a machine to open its detail modal
 
 Press `Enter` on a machine to see:
@@ -133,7 +137,9 @@ Press `Enter` on a machine to see:
 - **Network interfaces** — name, IP address, MAC address and Juju space for each NIC
 - **SAAS** — consumed remote offers and their status
 - **Offers** — cross-model offers with active/total connection counts
-- **Integrations** — regular and cross-model relations (peer relations hidden by default; press `p` to toggle)
+- **Integrations** — regular and cross-model relations with live status column (peer relations hidden by default; press `p` to toggle); relations being removed show as `removing`
+
+Each panel can be collapsed individually with `x` while it has focus, and expanded again with `x`. The focused panel is highlighted with a distinct border colour (violet in Monokai and Ubuntu themes).
 
 ### Health
 Shows a summary of all models across all controllers, highlighting those with errors or blocked units. Unhealthy models are shown by default; press `f` to toggle between unhealthy-only and all models.

--- a/guide/usage.md
+++ b/guide/usage.md
@@ -30,6 +30,7 @@
 | `Esc` | Clear filter |
 | `p` | Toggle peer relations in the Integrations panel |
 | `u` | Toggle units-per-machine in the Machines panel |
+| `x` | Collapse/expand the current panel |
 | `Enter` on app | Open App Config viewer |
 | `Enter` on offer | Open Offer detail |
 | `Enter` on relation | Open Relation Data inspector |
@@ -72,15 +73,17 @@
 The main view. Displays a full `juju status`-style breakdown of the selected model:
 
 - **Applications** — name, charm, channel, revision, units, status and workload message
-- **Units** — workload/agent status, machine or pod, address, ports
+- **Units** — workload/agent status, machine or pod, address, ports; leader units marked with `*`
 - **Machines** — id, state, address, instance, base, AZ *(IaaS models only)*
 - **SAAS** — consumed remote offers and their status
 - **Offers** — cross-model offers with active/total connection counts
-- **Integrations** — all relations (peer hidden by default; press `p` to show/hide)
+- **Integrations** — all relations with live status column (peer hidden by default; press `p` to show/hide); relations being removed show as `removing`
 
 Press `Enter` on any app to open its [Config viewer](#app-config-viewer), or on any relation to open the [Relation Data inspector](#relation-data-inspector), or on any machine to open the [Machine detail modal](#machine-detail-modal).
 
 In the **Machines** panel, press `u` to expand each machine and see which units (including subordinates) are running on it.
+
+Press `x` on any panel to collapse it to just its title bar, freeing up screen space. Press `x` again to expand it. The panel with focus is highlighted with a distinct border colour (violet in Monokai and Ubuntu themes).
 
 ### Health
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jujumate"
-version = "0.2.6"
+version = "0.2.7"
 
 description = "Terminal UI for Juju infrastructure orchestration"
 readme = "README.md"

--- a/src/jujumate/screens/help_screen.py
+++ b/src/jujumate/screens/help_screen.py
@@ -10,28 +10,29 @@ from textual.widgets import Static
 HELP_TEXT = """\
 
 [bold cyan]Navigation[/bold cyan]
-  [bold]c[/bold]       Clouds
-  [bold]m[/bold]       Models
-  [bold]s[/bold]       Status
-  [bold]h[/bold]       Health
+  [bold]c[/bold]           Clouds
+  [bold]h[/bold]           Health
+  [bold]m[/bold]           Models
+  [bold]s[/bold]           Status
 
 [bold cyan]Actions[/bold cyan]
-  [bold]Enter[/bold]   Drill-down / view app config, relation data or machine detail
-  [bold]/[/bold]       Filter (Status tab) — Esc to clear
-  [bold]f[/bold]       Toggle unhealthy / all models (Health tab)
-  [bold]S[/bold]       Secrets (requires model selected)
-  [bold]O[/bold]       Offers — all offers across controller
-  [bold]L[/bold]       Logs — live log stream (requires model selected)
-  [bold]C[/bold]       Settings — appearance, behaviour & diagnostics
-  [bold]r[/bold]       Refresh data
-  [bold]y[/bold]       Copy to clipboard (relation data / status)
-  [bold]p[/bold]       Toggle peer relations (Status → Integrations)
-  [bold]u[/bold]       Toggle units per machine (Status → Machines)
-  [bold]Esc[/bold]     Clear filter
-  [bold]q[/bold]       Quit
+  [bold]/[/bold]           Filter (Status tab) — Esc to clear
+  [bold]Enter[/bold]       Drill-down / view app config, relation data or machine detail
+  [bold]Esc[/bold]         Clear filter
+  [bold]f[/bold]           Toggle unhealthy / all models (Health tab)
+  [bold]p[/bold]           Toggle peer relations (Status → Integrations)
+  [bold]q[/bold]           Quit
+  [bold]r[/bold]           Refresh data
+  [bold]u[/bold]           Toggle units per machine (Status → Machines)
+  [bold]x[/bold]           Collapse/expand current panel (Status)
+  [bold]y[/bold]           Copy to clipboard (relation data / status)
+  [bold]Shift + c[/bold]   Settings — appearance, behaviour & diagnostics
+  [bold]Shift + l[/bold]   Logs — live log stream (requires model selected)
+  [bold]Shift + o[/bold]   Offers — all offers across controller
+  [bold]Shift + s[/bold]   Secrets (requires model selected)
 
 [bold cyan]Help[/bold cyan]
-  [bold]?[/bold]       Toggle this help
+  [bold]?[/bold]           Toggle this help
 """
 
 

--- a/src/jujumate/themes/dark.yaml
+++ b/src/jujumate/themes/dark.yaml
@@ -15,6 +15,7 @@ variables:
   muted: "#888888"
   pulse-off: "#004d26"
   blocked: "#FF8800"
+  focus-border: "#19B6EE"   # cyan (link color) — focus indicator
   log-trace:   "#888888"   # same as muted
   log-debug:   "#19B6EE"   # cyan
   log-info:    "#26A269"   # green (same as success)

--- a/src/jujumate/themes/monokai.yaml
+++ b/src/jujumate/themes/monokai.yaml
@@ -26,6 +26,7 @@ variables:
   link:    "#66D9EF"      # Monokai cyan    — URLs, IPs, consume access
   muted:   "#75715E"      # Monokai comments color — dim / unknown
   pulse-off: "#233E1E"    # monokai-diff-green-base — dark green for pulse dim state
+  focus-border: "#AE81FF" # Monokai violet — focus indicator
   log-trace:   "#75715E"  # comment muted
   log-debug:   "#66D9EF"  # cyan
   log-info:    "#A6E22E"  # green

--- a/src/jujumate/themes/solarized-dark.yaml
+++ b/src/jujumate/themes/solarized-dark.yaml
@@ -26,6 +26,7 @@ variables:
   link:    "#268bd2"      # blue    — URLs, IPs, consume access
   muted:   "#586e75"      # base01  — comments / secondary content / unknown
   pulse-off: "#5b7300"    # green-d — dark green for pulse dim state
+  focus-border: "#2aa198" # cyan/teal (secondary) — focus indicator
   log-trace:   "#586e75"  # base01 muted
   log-debug:   "#268bd2"  # blue
   log-info:    "#859900"  # green

--- a/src/jujumate/themes/spacemacs.yaml
+++ b/src/jujumate/themes/spacemacs.yaml
@@ -26,6 +26,7 @@ variables:
   link:    "#2aa1ae"      # comment/cyan — URLs, IPs, consume access
   muted:   "#686868"      # base-dim     — unknown / inactive / read-only
   pulse-off: "#294a10"    # Dark Spacemacs green for pulse dim state
+  focus-border: "#bc6ec5" # Spacemacs purple — focus indicator
   log-trace:   "#686868"  # base-dim muted
   log-debug:   "#2aa1ae"  # cyan
   log-info:    "#67b11d"  # green

--- a/src/jujumate/themes/ubuntu.yaml
+++ b/src/jujumate/themes/ubuntu.yaml
@@ -17,6 +17,7 @@ variables:
   muted: "#888888"
   pulse-off: "#004d26"
   blocked: "#FF8800"
+  focus-border: "#77216F"   # Ubuntu aubergine — focus indicator
   log-trace:   "#888888"
   log-debug:   "#19B6EE"
   log-info:    "#26A269"

--- a/src/jujumate/widgets/resource_table.py
+++ b/src/jujumate/widgets/resource_table.py
@@ -4,7 +4,9 @@ from typing import Any
 
 from textual import events
 from textual.app import ComposeResult
+from textual.css.query import NoMatches
 from textual.message import Message
+from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import DataTable, Label
 
@@ -18,6 +20,8 @@ class Column:
 
 class ResourceTable(Widget):
     """Generic reusable DataTable for displaying Juju resources."""
+
+    collapsed: reactive[bool] = reactive(False, init=False)
 
     class TableFocused(Message):
         """Posted (bubbling) when the internal DataTable gains focus."""
@@ -89,3 +93,25 @@ class ResourceTable(Widget):
         """Show or hide a loading indicator."""
         self._is_loading = loading
         self.loading = loading
+
+    def _watch_collapsed(self, value: bool) -> None:
+        try:
+            dt = self.query_one(DataTable)
+            label = self.query_one("#empty-label")
+        except NoMatches:
+            return
+        if value:
+            dt.display = False
+            label.display = False
+            self.can_focus = True
+            self.add_class("collapsed")
+            self.focus()
+        else:
+            self.remove_class("collapsed")
+            self.can_focus = False
+            dt.display = True
+            self.query_one(DataTable).focus()
+
+    def _on_focus(self, event: events.Focus) -> None:
+        if self.collapsed:
+            self.post_message(ResourceTable.TableFocused(self))

--- a/src/jujumate/widgets/status_view.py
+++ b/src/jujumate/widgets/status_view.py
@@ -6,6 +6,7 @@ from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, VerticalScroll
+from textual.css.query import NoMatches
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
@@ -239,6 +240,7 @@ class StatusView(Widget):
     BINDINGS = [
         Binding("/", "activate_filter", show=False),
         Binding("escape", "close_filter", show=False),
+        Binding("x", "toggle_collapse", "Collapse/expand panel", show=False),
         Binding("y", "copy_to_clipboard", "Copy status", show=False),
         Binding("p", "toggle_peer_relations", "Toggle peer relations", show=False),
         Binding("u", "toggle_units_in_machines", "Toggle units in machines", show=False),
@@ -345,7 +347,7 @@ class StatusView(Widget):
     def _update_scroll_indicator(self) -> None:
         try:
             vs = self.query_one("#status-scroll", _TrackedScroll)
-        except Exception:
+        except NoMatches:
             return
         at_bottom = vs.scroll_y >= vs.max_scroll_y
         self._show_more = not at_bottom and vs.max_scroll_y > 0
@@ -356,7 +358,7 @@ class StatusView(Widget):
     def _watch__show_more(self, value: bool) -> None:
         try:
             self.query_one("#scroll-indicator").display = value
-        except Exception:
+        except NoMatches:
             pass
 
     def update_apps(self, apps: list[AppInfo]) -> None:
@@ -595,11 +597,11 @@ class StatusView(Widget):
                 return
             msgs = self._row_messages.get(table_id, [])
             msg = msgs[event.cursor_row] if event.cursor_row < len(msgs) else ""
-        except Exception:
+        except AttributeError:
             msg = ""
         try:
             self.query_one("#msg-bar", Label).update(msg)
-        except Exception:
+        except NoMatches:
             pass
 
     def on_resource_table_table_focused(self, event: ResourceTable.TableFocused) -> None:
@@ -614,7 +616,7 @@ class StatusView(Widget):
             msgs = self._row_messages.get(table_id, [])
             msg = msgs[row] if row < len(msgs) else ""
             self.query_one("#msg-bar", Label).update(msg)
-        except Exception:
+        except NoMatches:
             pass
 
     def _restore_cursor(self, table_id: str, row_count: int) -> None:
@@ -628,7 +630,7 @@ class StatusView(Widget):
             last_row = self._last_cursor.get(table_id, 0)
             row = min(last_row, max(row_count - 1, 0))
             dt.move_cursor(row=row)
-        except Exception:
+        except NoMatches:
             pass
 
     def update_relations(self, relations: list[RelationInfo]) -> None:
@@ -681,34 +683,34 @@ class StatusView(Widget):
                     machine = self._displayed_machines[idx]
                     if machine is not None:
                         self.post_message(StatusView.MachineSelected(machine))
-        except Exception:
+        except AttributeError:
             pass
 
     def _rerender_all(self) -> None:
         """Re-apply the current filter to all tables."""
         try:
             self._render_apps()
-        except Exception:
+        except NoMatches:
             pass
         try:
             self._render_saas()
-        except Exception:
+        except NoMatches:
             pass
         try:
             self._render_units()
-        except Exception:
+        except NoMatches:
             pass
         try:
             self._render_offers()
-        except Exception:
+        except NoMatches:
             pass
         try:
             self._render_machines()
-        except Exception:
+        except NoMatches:
             pass
         try:
             self._render_relations()
-        except Exception:
+        except NoMatches:
             pass
 
     def check_action(self, action: str, parameters: tuple) -> bool | None:
@@ -716,7 +718,7 @@ class StatusView(Widget):
             try:
                 bar = self.query_one("#filter-bar")
                 return "visible" in bar.classes or bool(self._filter)
-            except Exception:
+            except NoMatches:
                 return False
         return True
 
@@ -732,6 +734,16 @@ class StatusView(Widget):
         self._filter = ""
         self.query_one("#filter-bar").remove_class("visible")
         self._rerender_all()
+
+    def action_toggle_collapse(self) -> None:
+        """Collapse or expand the currently active panel."""
+        if not self._last_active_table:
+            return
+        try:
+            table = self.query_one(f"#{self._last_active_table}", ResourceTable)
+            table.collapsed = not table.collapsed
+        except NoMatches:
+            pass
 
     def _update_rels_border_title(self) -> None:
         table = self.query_one("#status-rels-table", ResourceTable)

--- a/src/jujumate/widgets/status_view.tcss
+++ b/src/jujumate/widgets/status_view.tcss
@@ -15,6 +15,14 @@ StatusView ResourceTable {
     margin-bottom: 0;
     padding: 1 1 0 1;
 }
+StatusView ResourceTable:focus-within,
+StatusView ResourceTable:focus {
+    border: solid $focus-border;
+    border-title-color: $focus-border;
+}
+StatusView ResourceTable.collapsed {
+    padding: 0;
+}
 StatusView DataTable {
     height: auto;
     border: none;

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,6 +5,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 from textual import events
+from textual.css.query import NoMatches
 from textual.widgets import DataTable, Input, Label, TabbedContent
 from textual.widgets._data_table import RowKey
 
@@ -1052,6 +1053,63 @@ async def test_resource_table_table_focused_event_posts_message(pilot):
     assert any(isinstance(m, ResourceTable.TableFocused) for m in posted)
 
 
+@pytest.mark.asyncio
+async def test_resource_table_collapsed_hides_datatable(pilot):
+    # GIVEN a mounted ResourceTable with a row
+    view = ResourceTable(columns=[Column("Name", "name")], id="test-rt-collapse")
+    await _mount_view(pilot, view)
+    view.update_rows([("pg",)])
+    await pilot.pause()
+
+    # WHEN collapsed is set to True
+    view.collapsed = True
+    await pilot.pause()
+
+    # THEN DataTable is hidden, the widget becomes focusable, and focus moves to it
+    assert view.query_one(DataTable).display is False
+    assert view.can_focus is True
+    assert "collapsed" in view.classes
+    assert pilot.app.focused is view
+
+
+@pytest.mark.asyncio
+async def test_resource_table_expanded_shows_datatable(pilot):
+    # GIVEN a collapsed ResourceTable
+    view = ResourceTable(columns=[Column("Name", "name")], id="test-rt-expand")
+    await _mount_view(pilot, view)
+    view.update_rows([("pg",)])
+    view.collapsed = True
+    await pilot.pause()
+
+    # WHEN collapsed is set back to False
+    view.collapsed = False
+    await pilot.pause()
+
+    # THEN DataTable is visible, widget is no longer focusable, focus moves to DataTable
+    assert view.query_one(DataTable).display is True
+    assert view.can_focus is False
+    assert "collapsed" not in view.classes
+    assert pilot.app.focused is view.query_one(DataTable)
+
+
+@pytest.mark.asyncio
+async def test_resource_table_on_focus_when_collapsed_posts_table_focused(pilot):
+    # GIVEN a collapsed ResourceTable (can_focus=True)
+    view = ResourceTable(columns=[Column("Name", "name")], id="test-rt-focus-collapsed")
+    await _mount_view(pilot, view)
+    view.collapsed = True
+    await pilot.pause()
+
+    posted: list = []
+    with patch.object(view, "post_message", side_effect=posted.append):
+        # WHEN the ResourceTable itself receives focus (collapsed state)
+        view._on_focus(MagicMock())
+        await pilot.pause()
+
+    # THEN a TableFocused message is posted
+    assert any(isinstance(m, ResourceTable.TableFocused) for m in posted)
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # StatusView — filter, row selection, messages, saas
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1293,6 +1351,78 @@ async def test_status_view_action_toggle_units_in_machines_shows_and_hides(pilot
     # THEN only the machine row is shown again
     assert dt.row_count == 1
     assert view._show_units_in_machines is False
+
+
+@pytest.mark.asyncio
+async def test_status_view_action_toggle_collapse_collapses_active_panel(pilot):
+    # GIVEN a StatusView with the apps table as the last active table
+    view = pilot.app.screen.query_one("#status-view", StatusView)
+    rt = view.query_one("#status-apps-table", ResourceTable)
+    view._last_active_table = "status-apps-table"
+    await pilot.pause()
+
+    # WHEN action_toggle_collapse is called
+    view.action_toggle_collapse()
+    await pilot.pause()
+
+    # THEN the apps ResourceTable is collapsed
+    assert rt.collapsed is True
+    assert rt.query_one(DataTable).display is False
+
+
+@pytest.mark.asyncio
+async def test_status_view_action_toggle_collapse_expands_collapsed_panel(pilot):
+    # GIVEN a collapsed apps panel as the active table
+    view = pilot.app.screen.query_one("#status-view", StatusView)
+    rt = view.query_one("#status-apps-table", ResourceTable)
+    view._last_active_table = "status-apps-table"
+    rt.collapsed = True
+    await pilot.pause()
+
+    # WHEN action_toggle_collapse is called again
+    view.action_toggle_collapse()
+    await pilot.pause()
+
+    # THEN the apps ResourceTable is expanded
+    assert rt.collapsed is False
+    assert rt.query_one(DataTable).display is True
+
+
+@pytest.mark.asyncio
+async def test_status_view_action_toggle_collapse_no_active_table_is_noop(pilot):
+    # GIVEN no active table is set
+    view = pilot.app.screen.query_one("#status-view", StatusView)
+    view._last_active_table = ""
+
+    # WHEN action_toggle_collapse is called
+    view.action_toggle_collapse()
+    await pilot.pause()
+
+    # THEN no panel is collapsed (all remain expanded)
+    for rt in view.query(ResourceTable):
+        assert rt.collapsed is False
+
+
+@pytest.mark.asyncio
+async def test_resource_table_watch_collapsed_before_mount_is_safe(pilot):
+    # GIVEN a ResourceTable that is not yet mounted (query_one will raise)
+    view = ResourceTable(columns=[Column("Name", "name")], id="test-rt-premount")
+
+    # WHEN collapsed is set before mounting (watch fires, query_one fails)
+    # THEN no exception is raised
+    view._watch_collapsed(True)
+
+
+@pytest.mark.asyncio
+async def test_status_view_action_toggle_collapse_invalid_id_is_safe(pilot):
+    # GIVEN a StatusView with a _last_active_table pointing to a nonexistent widget
+    view = pilot.app.screen.query_one("#status-view", StatusView)
+    view._last_active_table = "nonexistent-table-id"
+
+    # WHEN action_toggle_collapse is called
+    # THEN no exception is raised
+    view.action_toggle_collapse()
+    await pilot.pause()
 
 
 @pytest.mark.asyncio
@@ -1842,13 +1972,13 @@ async def test_status_view_row_highlighted_has_focus_sets_active_table(pilot):
 
 @pytest.mark.asyncio
 async def test_status_view_resource_table_focused_exception_safe(pilot):
-    """Lines 480-481: exception in on_resource_table_table_focused is silently swallowed."""
-    # GIVEN a StatusView and a broken event whose query_one raises
+    """on_resource_table_table_focused: NoMatches from query_one is silently swallowed."""
+    # GIVEN a StatusView and a broken event whose query_one raises NoMatches
     view = pilot.app.screen.query_one("#status-view", StatusView)
 
     broken_event = MagicMock()
     broken_event.resource_table.id = "status-apps-table"
-    broken_event.resource_table.query_one = MagicMock(side_effect=RuntimeError("broken"))
+    broken_event.resource_table.query_one = MagicMock(side_effect=NoMatches("broken"))
 
     # WHEN the handler is called
     # THEN no exception propagates
@@ -1857,14 +1987,14 @@ async def test_status_view_resource_table_focused_exception_safe(pilot):
 
 @pytest.mark.asyncio
 async def test_status_view_row_selected_exception_safe(pilot):
-    """Lines 530-531: exception in on_data_table_row_selected is silently swallowed."""
-    # GIVEN a StatusView and an event whose data_table property raises
+    """on_data_table_row_selected: AttributeError from data_table access is silently swallowed."""
+    # GIVEN a StatusView and an event whose data_table property raises AttributeError
     view = pilot.app.screen.query_one("#status-view", StatusView)
 
     class _BadEvent:
         @property
         def data_table(self):
-            raise RuntimeError("bad table")
+            raise AttributeError("bad table")
 
     # WHEN the handler is called with the bad event
     # THEN no exception propagates
@@ -1873,17 +2003,17 @@ async def test_status_view_row_selected_exception_safe(pilot):
 
 @pytest.mark.asyncio
 async def test_status_view_rerender_all_exception_safe(pilot):
-    """Lines 537-558: all six render methods raise — _rerender_all swallows each."""
-    # GIVEN a StatusView where every render method raises an exception
+    """_rerender_all: NoMatches from each render method is swallowed individually."""
+    # GIVEN a StatusView where every render method raises NoMatches
     view = pilot.app.screen.query_one("#status-view", StatusView)
 
     with (
-        patch.object(view, "_render_apps", side_effect=Exception),
-        patch.object(view, "_render_saas", side_effect=Exception),
-        patch.object(view, "_render_units", side_effect=Exception),
-        patch.object(view, "_render_offers", side_effect=Exception),
-        patch.object(view, "_render_machines", side_effect=Exception),
-        patch.object(view, "_render_relations", side_effect=Exception),
+        patch.object(view, "_render_apps", side_effect=NoMatches),
+        patch.object(view, "_render_saas", side_effect=NoMatches),
+        patch.object(view, "_render_units", side_effect=NoMatches),
+        patch.object(view, "_render_offers", side_effect=NoMatches),
+        patch.object(view, "_render_machines", side_effect=NoMatches),
+        patch.object(view, "_render_relations", side_effect=NoMatches),
     ):
         # WHEN _rerender_all is called
         # THEN no exception propagates
@@ -1892,12 +2022,12 @@ async def test_status_view_rerender_all_exception_safe(pilot):
 
 @pytest.mark.asyncio
 async def test_status_view_check_action_close_filter_exception_safe(pilot):
-    """Lines 565-566: query_one raises in check_action → returns False."""
-    # GIVEN a StatusView where query_one raises
+    """check_action: NoMatches from query_one returns False instead of propagating."""
+    # GIVEN a StatusView where query_one raises NoMatches
     view = pilot.app.screen.query_one("#status-view", StatusView)
 
     # WHEN check_action is called
-    with patch.object(view, "query_one", side_effect=Exception("no widget")):
+    with patch.object(view, "query_one", side_effect=NoMatches("no widget")):
         result = view.check_action("close_filter", ())
 
     # THEN False is returned instead of propagating the exception

--- a/uv.lock
+++ b/uv.lock
@@ -711,7 +711,7 @@ wheels = [
 
 [[package]]
 name = "jujumate"
-version = "0.2.5"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "juju" },


### PR DESCRIPTION
This PR fixes #40 


 ## What's new
 
 ### Collapsible panels (`x`)
 Press `x` on any focused panel in the Status tab to collapse it to its title bar,
 freeing up screen space. Press `x` again to expand it. Focus is retained on the
 panel header when collapsed, so a second `x` expands without needing to Tab around.
 
 ### Focused panel highlight
 The active panel's border changes to a theme-specific colour (`$focus-border`) when
 it has focus, making it easy to see where you are at a glance. Each built-in theme
 defines its own native colour for this variable.
 
 
 ### UX polish
 - Help overlay (`?`) shortcuts are now sorted alphabetically; uppercase shortcuts are
   shown as `Shift + <letter>` (e.g. `Shift + c`) following standard key notation.
 - `except Exception` replaced with specific `NoMatches` / `AttributeError` throughout
   `status_view.py` and `resource_table.py`.
 
 ## Docs
 - `README.md` and `guide/usage.md` updated with new keybinding, panel collapse
   behaviour, leader markers, and relation status column.