### PR TITLE
fix css error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jujumate"
-version = "0.2.8"
+version = "0.2.9"
 
 description = "Terminal UI for Juju infrastructure orchestration"
 readme = "README.md"

--- a/src/jujumate/app.py
+++ b/src/jujumate/app.py
@@ -34,10 +34,12 @@ class JujuMateApp(App):
     def __init__(self, settings: AppSettings | None = None) -> None:
         super().__init__()
         self._settings = settings or load_settings()
+        # Register themes in __init__ so their CSS variables (e.g. $focus-border)
+        # are available when widget DEFAULT_CSS is compiled — before on_mount runs.
+        self._apply_theme()
 
     def on_mount(self) -> None:
         asyncio.get_event_loop().set_exception_handler(_asyncio_exception_handler)
-        self._apply_theme()
         logger.info("JujuMate started")
         self.push_screen(MainScreen())
 

--- a/uv.lock
+++ b/uv.lock
@@ -711,7 +711,7 @@ wheels = [
 
 [[package]]
 name = "jujumate"
-version = "0.2.7"
+version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "juju" },


### PR DESCRIPTION
This PR fixes this error:


```shell
$ jujumate
 Error in stylesheet:
 /snap/jujumate/x1/lib/python3.12/site-packages/jujumate/widgets/status_view.py, StatusView.DEFAULT_CSS:20:19
╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│   18 StatusView ResourceTable:focus-within,                                                                                                                   │
│   19 StatusView ResourceTable:focus {                                                                                                                         │
│ ❱ 20 │   border: solid $focus-border;                                                                                                                         │
│   21 │   border-title-color: $focus-border;                                                                                                                   │
│   22 }                                                                                                                                                        │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 • reference to undefined variable '$focus-border'                                                                                                               
 • did you mean '$border'?    
```