### PR TITLE
feat: replace cascade tabs with unified Navigator view

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@
 ## Features
 
 - 🔄 **Auto-refresh** — status updates automatically every few seconds; logs stream live via WebSocket
-- ☁️ **Full resource tree** — clouds, controllers, models, applications, units, machines
-- 📊 **Status view** — apps, units, offers, integrations, SAAS and machines in one screen
+- 🧭 **Navigator** — unified Cloud → Controller → Model navigation in a single tab with cascade filtering and a detail strip showing key fields of the current selection
+- 📊 **Status view** — apps, units, offers, integrations, SAAS, machines and storage in one screen
 - 🏥 **Health view** — shows only unhealthy models by default; toggle to see all with `f`
-- 🔍 **Drill-down navigation** — select a controller → filter models; select a model → see its full status
+- 💾 **Storage panel** — storage volumes, pools and sizes; toggle detached storage with `d`; press `Enter` to see device info and mountpoints
+- 🔍 **Drill-down navigation** — select a cloud → filter controllers → filter models → see full status. Enter auto-advances to the next selector
 - 🔎 **Inline filtering** — press `/` in Status or Logs to search with live highlight
 - 🔗 **Peer relation toggle** — press `p` to show/hide peer relations in the Integrations panel
 - 🖥️ **Units-per-machine toggle** — press `u` to show units (and their subordinates) nested under each machine
@@ -72,21 +73,21 @@ On first launch JujuMate connects to your current Juju controller and auto-selec
 
 | Key | Action |
 |-----|--------|
-| `c` | Go to Clouds tab |
-| `m` | Go to Models tab |
+| `n` | Go to Navigator tab (Clouds → Controllers → Models) |
 | `s` | Go to Status tab |
 | `h` | Go to Health tab |
 | `r` | Force refresh |
-| `Esc` | Clear cloud/controller drill-down filter |
+| `Esc` | Clear drill-down filter |
 | `?` | Toggle help overlay |
 | `q` | Quit |
 
-### Navigation
+### Navigator tab
 
 | Key | Action |
 |-----|--------|
-| `↑` / `↓` | Move cursor up/down |
-| `Enter` | Drill-down / open detail |
+| `↑` / `↓` | Move cursor within the active selector |
+| `Enter` | Select the highlighted item and advance focus to the next selector |
+| `Tab` / `Shift+Tab` | Move focus between Cloud, Controller and Model selectors |
 
 ### Status tab
 
@@ -94,6 +95,7 @@ On first launch JujuMate connects to your current Juju controller and auto-selec
 |-----|--------|
 | `/` | Filter by app name, charm, channel or message (with live highlight) |
 | `Esc` | Clear filter |
+| `d` | Toggle detached storage visibility in the Storage panel |
 | `p` | Toggle peer relations in the Integrations panel |
 | `u` | Toggle units (and subordinates) nested under each machine |
 | `x` | Collapse/expand the current panel |
@@ -125,11 +127,19 @@ On first launch JujuMate connects to your current Juju controller and auto-selec
 
 ## Views
 
+### Navigator
+The entry point for navigating your Juju estate. A single tab replaces the old Clouds / Controllers / Models tabs with a three-column cascade layout:
+
+- **Selector strip** — three compact tables side-by-side: Clouds (Name, Type), Controllers (Controller, Models) and Models (Model, Machines, Apps). Use `↑`/`↓` to move the cursor, `Enter` to select and auto-advance, and `Tab`/`Shift+Tab` to switch focus between selectors.
+- **Detail strip** — a horizontal panel above the selectors that shows the key fields of the currently selected cloud, controller and model. Updates as you navigate.
+- **Cascade filtering** — selecting a cloud filters controllers to that cloud; selecting a controller filters models to that controller. Changing a cloud resets the controllers and models below it.
+
 ### Status
 The main view. Displays a full `juju status`-style breakdown of the selected model:
 - **Applications** — name, charm, channel, revision, units, status and workload message
 - **Units** — workload/agent status, machine or pod, address, ports; subordinates shown nested under their principal; leader units are marked with `*`
 - **Machines** — id, state, address, instance, base, AZ *(IaaS models only)*; press `u` to expand units and their subordinates inline; press `Enter` on a machine to open its detail modal
+- **Storage** — storage instances with pool, size and mountpoint; toggle detached storage with `d`; press `Enter` on a storage entry to see device details
 
 Press `Enter` on a machine to see:
 - **Hardware** — architecture, CPU cores, memory, root disk size, virtualisation type

--- a/landing/index.html
+++ b/landing/index.html
@@ -75,13 +75,13 @@
         </div>
         <div class="feature-card">
           <div class="feature-icon">☁️</div>
-          <h3>Full resource tree</h3>
-          <p>Clouds, controllers, models, applications, units and machines — all in one place.</p>
+          <h3>Navigator</h3>
+          <p>Unified Cloud → Controller → Model navigation in a single tab. Cascade filtering, a detail strip showing key fields, and keyboard-driven selectors replace the old separate tabs.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon">📊</div>
           <h3>Status view</h3>
-          <p>Full <code>juju status</code>-style breakdown including offers, integrations, machines and SAAS. Toggle peer relations with <kbd>p</kbd>; expand units per machine with <kbd>u</kbd>. Press <kbd>Enter</kbd> on a machine to open a detail modal with hardware specs, status timestamps and network interfaces.</p>
+          <p>Full <code>juju status</code>-style breakdown including offers, integrations, machines, storage and SAAS. Toggle peer relations with <kbd>p</kbd>; expand units per machine with <kbd>u</kbd>; toggle detached storage with <kbd>d</kbd>. Press <kbd>Enter</kbd> on a machine to open a detail modal with hardware specs, status timestamps and network interfaces.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon">🏥</div>
@@ -91,7 +91,7 @@
         <div class="feature-card">
           <div class="feature-icon">🔍</div>
           <h3>Drill-down navigation</h3>
-          <p>Select a controller to filter models; select a model to filter the Status tab. Navigate your full resource tree with the keyboard.</p>
+          <p>Select a cloud to filter controllers; select a controller to filter models; select a model to see its full status. <kbd>Enter</kbd> auto-advances to the next selector. Navigate your full resource tree with the keyboard.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon">📜</div>
@@ -107,6 +107,11 @@
           <div class="feature-icon">🔐</div>
           <h3>Secrets browser</h3>
           <p>List and inspect Juju secrets per model with full metadata and revision history.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">💾</div>
+          <h3>Storage panel</h3>
+          <p>View storage volumes, pools and sizes. Toggle detached storage with <kbd>d</kbd>. Press <kbd>Enter</kbd> for device info and mountpoints.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon">🎨</div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jujumate"
-version = "0.3.1"
+version = "0.4.0"
 
 description = "Terminal UI for Juju infrastructure orchestration"
 readme = "README.md"

--- a/src/jujumate/screens/help_screen.py
+++ b/src/jujumate/screens/help_screen.py
@@ -10,13 +10,12 @@ from textual.widgets import Static
 HELP_TEXT = """\
 
 [bold cyan]Navigation[/bold cyan]
-  [bold]c[/bold]             Clouds
+  [bold]n[/bold]             Navigator (Clouds → Controllers → Models)
   [bold]h[/bold]             Health
-  [bold]m[/bold]             Models
   [bold]s[/bold]             Status
-  [bold]s[/bold]             Status
-  [bold]TAB[/bold]           Switch panels forward (Status)
-  [bold]Shift + TAB[/bold]   Switch panels backguards (Status)
+  [bold]TAB[/bold]           Move focus to next selector (Navigator) / Switch panels (Status)
+  [bold]Shift + TAB[/bold]   Move focus to prev selector (Navigator) / Switch panels (Status)
+  [bold]Enter[/bold]         Select item and advance to next selector (Navigator)
 
 [bold cyan]Actions[/bold cyan]
   [bold]/[/bold]             Filter (Status tab) — Esc to clear

--- a/src/jujumate/screens/main_screen.py
+++ b/src/jujumate/screens/main_screen.py
@@ -54,11 +54,9 @@ from jujumate.screens.secrets_screen import SecretsScreen
 from jujumate.screens.settings_screen import SettingsScreen
 from jujumate.screens.storage_detail_screen import StorageDetailScreen
 from jujumate.settings import AppSettings, load_settings, save_settings
-from jujumate.widgets.clouds_view import CloudsView
-from jujumate.widgets.controllers_view import ControllersView
 from jujumate.widgets.health_view import HealthView
 from jujumate.widgets.jujumate_header import HeaderContext, JujuMateHeader
-from jujumate.widgets.models_view import ModelsView
+from jujumate.widgets.navigator_view import NavigatorView
 from jujumate.widgets.status_view import StatusView
 
 logger = logging.getLogger(__name__)
@@ -68,8 +66,7 @@ _T = TypeVar("_T")
 
 class MainScreen(Screen):
     BINDINGS = [
-        Binding("c", "switch_tab('tab-clouds')", "Clouds"),
-        Binding("m", "switch_tab('tab-models')", "Models"),
+        Binding("n", "switch_tab('tab-navigator')", "Navigator"),
         Binding("s", "switch_tab('tab-status')", "Status"),
         Binding("h", "switch_tab('tab-health')", "Health"),
         Binding("f", "toggle_health_filter", "Toggle health filter", show=False),
@@ -84,9 +81,7 @@ class MainScreen(Screen):
     ]
 
     _TAB_FOCUS_MAP = {
-        "tab-clouds": "#clouds-table",
-        "tab-controllers": "#controllers-table",
-        "tab-models": "#models-table",
+        "tab-navigator": "#clouds-table",
         "tab-status": "#status-apps-table DataTable",
         "tab-health": "#health-models-table",
     }
@@ -125,13 +120,9 @@ class MainScreen(Screen):
 
     def compose(self) -> ComposeResult:
         yield JujuMateHeader(id="main-header")
-        with TabbedContent(initial="tab-clouds"):
-            with TabPane("Clouds", id="tab-clouds"):
-                yield CloudsView(id="clouds-view")
-            with TabPane("Controllers", id="tab-controllers"):
-                yield ControllersView(id="controllers-view")
-            with TabPane("Models", id="tab-models"):
-                yield ModelsView(id="models-view")
+        with TabbedContent(initial="tab-navigator"):
+            with TabPane("Navigator", id="tab-navigator"):
+                yield NavigatorView(id="navigator-view")
             with TabPane("Status", id="tab-status"):
                 yield StatusView(id="status-view")
             with TabPane("Health", id="tab-health"):
@@ -221,8 +212,7 @@ class MainScreen(Screen):
             return
         self._selected_cloud = None
         self._selected_controller = None
-        self._refresh_controllers_view()
-        self._refresh_models_view()
+        self.query_one("#navigator-view", NavigatorView).reset_selection()
         self._refresh_header()
         self.notify("Filter cleared")
 
@@ -294,24 +284,12 @@ class MainScreen(Screen):
 
     # ── Filter helpers ────────────────────────────────────────────────────────
 
-    def _refresh_controllers_view(self) -> None:
-        filtered = [
-            c
-            for c in self._all_controllers
-            if self._selected_cloud is None or c.cloud == self._selected_cloud
-        ]
-        self.query_one("#controllers-view", ControllersView).update(filtered)
-
-    def _refresh_models_view(self) -> None:
-        filtered = [
-            m
-            for m in self._all_models
-            if self._selected_controller is None or m.controller == self._selected_controller
-        ]
-        models_view = self.query_one("#models-view", ModelsView)
-        models_view.update(filtered)
+    def _refresh_navigator_view(self) -> None:
+        nav = self.query_one("#navigator-view", NavigatorView)
+        nav.update_controllers(self._all_controllers)
+        nav.update_models(self._all_models)
         if self._selected_model and self._selected_controller:
-            models_view.select_model(self._selected_controller, self._selected_model)
+            nav.select_model(self._selected_controller, self._selected_model)
 
     def _filter_by_model(self, items: list[_T]) -> list[_T]:
         """Return items whose .model matches the selected model (and .controller if set)."""
@@ -444,12 +422,12 @@ class MainScreen(Screen):
 
     def on_clouds_updated(self, message: CloudsUpdated) -> None:
         self._all_clouds = message.clouds
-        self.query_one("#clouds-view", CloudsView).update(message.clouds)
+        self.query_one("#navigator-view", NavigatorView).update_clouds(message.clouds)
         self._refresh_header()
 
     def on_controllers_updated(self, message: ControllersUpdated) -> None:
         self._all_controllers = message.controllers
-        self._refresh_controllers_view()
+        self._refresh_navigator_view()
         self._refresh_header()
 
     def on_models_updated(self, message: ModelsUpdated) -> None:
@@ -473,7 +451,7 @@ class MainScreen(Screen):
                     severity="warning",
                 )
                 self._selected_model = None
-                self.action_switch_tab("tab-models")
+                self.action_switch_tab("tab-navigator")
 
             # Prune stale relations / offers / SAAS for models that no longer exist.
             self._all_relations = [
@@ -483,7 +461,7 @@ class MainScreen(Screen):
             self._all_saas = [s for s in self._all_saas if (s.controller, s.model) in existing]
             self._all_models = message.models
 
-        self._refresh_models_view()
+        self._refresh_navigator_view()
         active = self._active_tab()
         if active == "tab-status":
             self._refresh_status_view()
@@ -599,7 +577,7 @@ class MainScreen(Screen):
             return
         self._selected_controller = model_info.controller
         self._selected_model = model_name
-        self._refresh_models_view()
+        self._refresh_navigator_view()
         self._refresh_status_view()
         self._refresh_header()
         self.action_switch_tab("tab-status")
@@ -615,37 +593,27 @@ class MainScreen(Screen):
 
     # ── Drill-down selection handlers ─────────────────────────────────────────
 
-    def on_clouds_view_cloud_selected(self, message: CloudsView.CloudSelected) -> None:
+    def on_navigator_view_cloud_selected(self, message: NavigatorView.CloudSelected) -> None:
         self._selected_cloud = message.name
         self._selected_controller = None
         self._selected_model = None
-        self._refresh_controllers_view()
-        self._refresh_models_view()
         self._refresh_status_view()
-        self.action_switch_tab("tab-controllers")
 
-    def on_controllers_view_controller_selected(
-        self, message: ControllersView.ControllerSelected
+    def on_navigator_view_controller_selected(
+        self, message: NavigatorView.ControllerSelected
     ) -> None:
         self._selected_controller = message.name
         self._selected_model = None
-        self._refresh_models_view()
         self._refresh_status_view()
-        filtered_count = sum(
-            1 for m in self._all_models if m.controller == self._selected_controller
-        )
         logger.debug(
-            "Controller selected: '%s' → %d models (total stored: %d, controllers in models: %s)",
+            "Controller selected: '%s' → %d models (total stored: %d)",
             self._selected_controller,
-            filtered_count,
+            sum(1 for m in self._all_models if m.controller == self._selected_controller),
             len(self._all_models),
-            list({m.controller for m in self._all_models}),
         )
         self._refresh_header()
-        self.action_switch_tab("tab-models")
 
-    def on_models_view_model_selected(self, message: ModelsView.ModelSelected) -> None:
-        # message.name is "controller/modelname"
+    def on_navigator_view_model_selected(self, message: NavigatorView.ModelSelected) -> None:
         parts = message.name.split("/", 1)
         if len(parts) == 2:
             self._selected_controller = parts[0]

--- a/src/jujumate/widgets/clouds_view.py
+++ b/src/jujumate/widgets/clouds_view.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any
 
 from textual.app import ComposeResult
@@ -12,14 +11,10 @@ from jujumate.widgets.resource_table import Column
 _COLUMNS = [
     Column("Name", "name"),
     Column("Type", "type", width=12),
-    Column("Regions", "regions", width=20),
-    Column("Credentials", "credentials", width=20),
 ]
 
 
 class CloudsView(Widget):
-    DEFAULT_CSS = (Path(__file__).parent / "clouds_view.tcss").read_text()
-
     class CloudSelected(Message):
         def __init__(self, name: str) -> None:
             super().__init__()
@@ -32,15 +27,7 @@ class CloudsView(Widget):
         yield NavigableTable(columns=_COLUMNS, id="clouds-table")
 
     def update(self, clouds: list[CloudInfo]) -> None:
-        rows = [
-            (
-                c.name,
-                c.type,
-                ", ".join(c.regions) if c.regions else "—",
-                ", ".join(c.credentials) if c.credentials else "—",
-            )
-            for c in clouds
-        ]
+        rows = [(c.name, c.type) for c in clouds]
         keys = [c.name for c in clouds]
         self.query_one(NavigableTable).update_rows(rows, keys=keys)
 

--- a/src/jujumate/widgets/clouds_view.tcss
+++ b/src/jujumate/widgets/clouds_view.tcss
@@ -1,1 +1,0 @@
-CloudsView { height: 1fr; }

--- a/src/jujumate/widgets/controllers_view.py
+++ b/src/jujumate/widgets/controllers_view.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any
 
 from textual.app import ComposeResult
@@ -10,17 +9,12 @@ from jujumate.widgets.navigable_table import NavigableTable
 from jujumate.widgets.resource_table import Column
 
 _COLUMNS = [
-    Column("Name", "name"),
-    Column("Cloud", "cloud", width=14),
-    Column("Region", "region", width=14),
-    Column("Juju Version", "version", width=14),
+    Column("Controller", "name"),
     Column("Models", "models", width=8),
 ]
 
 
 class ControllersView(Widget):
-    DEFAULT_CSS = (Path(__file__).parent / "controllers_view.tcss").read_text()
-
     class ControllerSelected(Message):
         def __init__(self, name: str) -> None:
             super().__init__()
@@ -33,9 +27,7 @@ class ControllersView(Widget):
         yield NavigableTable(columns=_COLUMNS, id="controllers-table")
 
     def update(self, controllers: list[ControllerInfo]) -> None:
-        rows = [
-            (c.name, c.cloud, c.region, c.juju_version, str(c.model_count)) for c in controllers
-        ]
+        rows = [(c.name, str(c.model_count)) for c in controllers]
         keys = [c.name for c in controllers]
         self.query_one(NavigableTable).update_rows(rows, keys=keys)
 

--- a/src/jujumate/widgets/controllers_view.tcss
+++ b/src/jujumate/widgets/controllers_view.tcss
@@ -1,1 +1,0 @@
-ControllersView { height: 1fr; }

--- a/src/jujumate/widgets/models_view.py
+++ b/src/jujumate/widgets/models_view.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any
 
 from textual.app import ComposeResult
@@ -10,18 +9,13 @@ from jujumate.widgets.navigable_table import NavigableTable
 from jujumate.widgets.resource_table import Column
 
 _COLUMNS = [
-    Column("Name", "name"),
-    Column("Controller", "controller", width=16),
-    Column("Cloud/Region", "cloud_region", width=18),
-    Column("Status", "status", width=12),
+    Column("Model", "name"),
     Column("Machines", "machines", width=10),
     Column("Apps", "apps", width=6),
 ]
 
 
 class ModelsView(Widget):
-    DEFAULT_CSS = (Path(__file__).parent / "models_view.tcss").read_text()
-
     class ModelSelected(Message):
         def __init__(self, name: str) -> None:
             super().__init__()
@@ -37,9 +31,6 @@ class ModelsView(Widget):
         rows = [
             (
                 m.name,
-                m.controller,
-                f"{m.cloud}/{m.region}" if m.region else m.cloud,
-                m.status,
                 str(m.machine_count),
                 str(m.app_count),
             )

--- a/src/jujumate/widgets/models_view.tcss
+++ b/src/jujumate/widgets/models_view.tcss
@@ -1,1 +1,0 @@
-ModelsView { height: 1fr; }

--- a/src/jujumate/widgets/navigable_table.py
+++ b/src/jujumate/widgets/navigable_table.py
@@ -4,7 +4,6 @@ from typing import Any
 from rich import box as rich_box
 from rich.table import Table
 from rich.text import Text
-from textual import events
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalScroll
@@ -27,6 +26,7 @@ class NavigableTable(Widget, can_focus=True):
     BINDINGS = [
         Binding("up", "cursor_up", show=False),
         Binding("down", "cursor_down", show=False),
+        Binding("enter", "select_row", show=False),
     ]
 
     DEFAULT_CSS = (Path(__file__).parent / "navigable_table.tcss").read_text()
@@ -85,8 +85,10 @@ class NavigableTable(Widget, can_focus=True):
         for col in self._columns:
             t.add_column(col.label, width=col.width)
         for i, row in enumerate(self._rows):
-            arrow = Text("❯", style=f"bold {palette.PRIMARY}") if i == self._cursor else Text("")
-            t.add_row(arrow, *row)
+            is_cursor = i == self._cursor
+            arrow = Text("❯", style=f"bold {palette.PRIMARY}") if is_cursor else Text(" ")
+            row_style = f"bold {palette.ACCENT}" if is_cursor else ""
+            t.add_row(arrow, *row, style=row_style)
 
         self.query_one("#nt-content", Static).update(t)
 
@@ -106,9 +108,8 @@ class NavigableTable(Widget, can_focus=True):
             self._cursor += 1
             self._refresh_content()
 
-    def on_key(self, event: events.Key) -> None:
-        if event.key == "enter" and self._rows:
+    def action_select_row(self) -> None:
+        if self._rows:
             key = self._keys[self._cursor] if self._keys else None
             if key:
-                event.stop()
                 self.post_message(NavigableTable.RowSelected(key))

--- a/src/jujumate/widgets/navigator_view.py
+++ b/src/jujumate/widgets/navigator_view.py
@@ -1,0 +1,237 @@
+"""Single-tab navigator combining cloud, controller and model selection with detail strip."""
+
+from pathlib import Path
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.message import Message
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static
+
+from jujumate import palette
+from jujumate.models.entities import CloudInfo, ControllerInfo, ModelInfo
+from jujumate.widgets.clouds_view import CloudsView
+from jujumate.widgets.controllers_view import ControllersView
+from jujumate.widgets.models_view import ModelsView
+
+
+def _detail_row(label: str, value: str, width: int = 14) -> str:
+    return f"  [bold]{label.ljust(width)}[/]{value}"
+
+
+class NavigatorView(Widget):
+    """Three-panel navigator: detail strip at top, selection tables at bottom.
+
+    Selecting a cloud filters the controllers list; selecting a controller
+    filters the models list; selecting a model posts ModelSelected.
+
+    The top strip shows key fields of the currently selected cloud,
+    controller and model respectively.
+    """
+
+    DEFAULT_CSS = (Path(__file__).parent / "navigator_view.tcss").read_text()
+
+    # ── messages ────────────────────────────────────────────────────────────
+
+    class CloudSelected(Message):
+        def __init__(self, name: str) -> None:
+            super().__init__()
+            self.name = name
+
+    class ControllerSelected(Message):
+        def __init__(self, name: str) -> None:
+            super().__init__()
+            self.name = name
+
+    class ModelSelected(Message):
+        def __init__(self, name: str) -> None:
+            super().__init__()
+            self.name = name
+
+    # ── state ────────────────────────────────────────────────────────────────
+
+    _selected_cloud: reactive[str | None] = reactive(None)
+    _selected_controller: reactive[str | None] = reactive(None)
+    _selected_model: reactive[str | None] = reactive(None)
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._all_clouds: list[CloudInfo] = []
+        self._all_controllers: list[ControllerInfo] = []
+        self._all_models: list[ModelInfo] = []
+
+    # ── compose ──────────────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        from textual.containers import Horizontal, Vertical
+
+        with Vertical(id="nav-container"):
+            with Horizontal(id="nav-detail-strip"):
+                yield Static("", id="nav-cloud-detail")
+                yield Static("", id="nav-controller-detail")
+                yield Static("", id="nav-model-detail")
+            with Horizontal(id="nav-selector-strip"):
+                yield CloudsView(id="clouds-view")
+                yield ControllersView(id="controllers-view")
+                yield ModelsView(id="models-view")
+
+    def on_mount(self) -> None:
+        self._refresh_cloud_detail()
+        self._refresh_controller_detail()
+        self._refresh_model_detail()
+
+    # ── public update API ────────────────────────────────────────────────────
+
+    def update_clouds(self, clouds: list[CloudInfo]) -> None:
+        self._all_clouds = clouds
+        self.query_one("#clouds-view", CloudsView).update(clouds)
+
+    def update_controllers(self, controllers: list[ControllerInfo]) -> None:
+        self._all_controllers = controllers
+        self._refresh_controllers_view()
+
+    def update_models(self, models: list[ModelInfo]) -> None:
+        self._all_models = models
+        self._refresh_models_view()
+
+    def select_model(self, controller: str, model: str) -> None:
+        self.query_one("#models-view", ModelsView).select_model(controller, model)
+
+    def reset_selection(self) -> None:
+        self._selected_cloud = None
+        self._selected_controller = None
+        self._selected_model = None
+        self._refresh_controllers_view()
+        self._refresh_models_view()
+        self._refresh_cloud_detail()
+        self._refresh_controller_detail()
+        self._refresh_model_detail()
+
+    # ── internal refresh helpers ─────────────────────────────────────────────
+
+    def _refresh_controllers_view(self) -> None:
+        filtered = [
+            c
+            for c in self._all_controllers
+            if self._selected_cloud is None or c.cloud == self._selected_cloud
+        ]
+        self.query_one("#controllers-view", ControllersView).update(filtered)
+
+    def _refresh_models_view(self) -> None:
+        if self._selected_controller is not None:
+            filtered = [m for m in self._all_models if m.controller == self._selected_controller]
+        elif self._selected_cloud is not None:
+            cloud_controllers = {
+                c.name for c in self._all_controllers if c.cloud == self._selected_cloud
+            }
+            filtered = [m for m in self._all_models if m.controller in cloud_controllers]
+        else:
+            filtered = list(self._all_models)
+        self.query_one("#models-view", ModelsView).update(filtered)
+
+    def _refresh_cloud_detail(self) -> None:
+        panel = self.query_one("#nav-cloud-detail", Static)
+        cloud = next((c for c in self._all_clouds if c.name == self._selected_cloud), None)
+        if cloud is None:
+            panel.update(self._placeholder("Cloud"))
+            panel.border_title = f"[{palette.MUTED}]Cloud[/]"
+            return
+        regions = ", ".join(cloud.regions[:3]) if cloud.regions else "—"
+        if len(cloud.regions) > 3:
+            regions += f" +{len(cloud.regions) - 3}"
+        creds = str(len(cloud.credentials)) if cloud.credentials else "0"
+        lines = [
+            f"  [{palette.ACCENT}]{cloud.name}[/]",
+            _detail_row("Type", cloud.type),
+            _detail_row("Regions", f"{len(cloud.regions)}  [{palette.MUTED}]{regions}[/]"),
+            _detail_row("Credentials", creds),
+        ]
+        panel.update("\n".join(lines))
+        panel.border_title = f"[{palette.SUCCESS}]Cloud[/]"
+
+    def _refresh_controller_detail(self) -> None:
+        panel = self.query_one("#nav-controller-detail", Static)
+        ctrl = next((c for c in self._all_controllers if c.name == self._selected_controller), None)
+        if ctrl is None:
+            panel.update(self._placeholder("Controller"))
+            panel.border_title = f"[{palette.MUTED}]Controller[/]"
+            return
+        lines = [
+            f"  [{palette.ACCENT}]{ctrl.name}[/]",
+            _detail_row("Cloud", ctrl.cloud),
+            _detail_row("Region", ctrl.region or "—"),
+            _detail_row("Juju", ctrl.juju_version or "—"),
+            _detail_row("Models", str(ctrl.model_count)),
+        ]
+        panel.update("\n".join(lines))
+        panel.border_title = f"[{palette.SUCCESS}]Controller[/]"
+
+    def _refresh_model_detail(self) -> None:
+        panel = self.query_one("#nav-model-detail", Static)
+        model = next(
+            (
+                m
+                for m in self._all_models
+                if self._selected_model
+                and m.name == self._selected_model
+                and (not self._selected_controller or m.controller == self._selected_controller)
+            ),
+            None,
+        )
+        if model is None:
+            panel.update(self._placeholder("Model"))
+            panel.border_title = f"[{palette.MUTED}]Model[/]"
+            return
+        status_color = palette.status_color(model.status) or palette.MUTED
+        lines = [
+            f"  [{palette.ACCENT}]{model.name}[/]",
+            _detail_row("Status", f"[{status_color}]{model.status}[/]"),
+            _detail_row("Controller", model.controller),
+            _detail_row("Machines", str(model.machine_count)),
+            _detail_row("Apps", str(model.app_count)),
+        ]
+        panel.update("\n".join(lines))
+        panel.border_title = f"[{palette.SUCCESS}]Model[/]"
+
+    @staticmethod
+    def _placeholder(label: str) -> str:
+        return f"  [{palette.MUTED}]— select a {label.lower()} —[/]"
+
+    # ── event handlers ───────────────────────────────────────────────────────
+
+    def on_clouds_view_cloud_selected(self, message: CloudsView.CloudSelected) -> None:
+        message.stop()
+        self._selected_cloud = message.name
+        self._selected_controller = None
+        self._selected_model = None
+        self._refresh_controllers_view()
+        self._refresh_models_view()
+        self._refresh_cloud_detail()
+        self._refresh_controller_detail()
+        self._refresh_model_detail()
+        self.post_message(NavigatorView.CloudSelected(message.name))
+        self.call_after_refresh(self.query_one("#controllers-table").focus)
+
+    def on_controllers_view_controller_selected(
+        self, message: ControllersView.ControllerSelected
+    ) -> None:
+        message.stop()
+        self._selected_controller = message.name
+        self._selected_model = None
+        self._refresh_models_view()
+        self._refresh_controller_detail()
+        self._refresh_model_detail()
+        self.post_message(NavigatorView.ControllerSelected(message.name))
+        self.call_after_refresh(self.query_one("#models-table").focus)
+
+    def on_models_view_model_selected(self, message: ModelsView.ModelSelected) -> None:
+        message.stop()
+        parts = message.name.split("/", 1)
+        if len(parts) == 2:
+            self._selected_controller = parts[0]
+            self._selected_model = parts[1]
+        else:
+            self._selected_model = message.name
+        self._refresh_model_detail()
+        self.post_message(NavigatorView.ModelSelected(message.name))

--- a/src/jujumate/widgets/navigator_view.tcss
+++ b/src/jujumate/widgets/navigator_view.tcss
@@ -1,0 +1,40 @@
+NavigatorView {
+    height: 1fr;
+}
+
+#nav-container {
+    height: 1fr;
+}
+
+#nav-detail-strip {
+    height: auto;
+    min-height: 8;
+}
+
+#nav-cloud-detail,
+#nav-controller-detail,
+#nav-model-detail {
+    width: 1fr;
+    border: round $panel;
+    padding: 0 1;
+    height: auto;
+    min-height: 7;
+}
+
+#nav-selector-strip {
+    height: 1fr;
+}
+
+CloudsView,
+ControllersView,
+ModelsView {
+    width: 1fr;
+    height: 1fr;
+    border: round $panel;
+}
+
+CloudsView:focus-within,
+ControllersView:focus-within,
+ModelsView:focus-within {
+    border: round $accent;
+}

--- a/tests/test_main_screen.py
+++ b/tests/test_main_screen.py
@@ -55,11 +55,8 @@ from jujumate.screens.storage_detail_screen import StorageDetailScreen
 from jujumate.screens.theme_screen import ThemeScreen
 from jujumate.settings import AppSettings
 from jujumate.widgets.app_config_view import AppConfigView
-from jujumate.widgets.clouds_view import CloudsView
-from jujumate.widgets.controllers_view import ControllersView
 from jujumate.widgets.health_view import HealthView
-from jujumate.widgets.models_view import ModelsView
-from jujumate.widgets.navigable_table import NavigableTable
+from jujumate.widgets.navigator_view import NavigatorView
 from jujumate.widgets.relation_data_view import RelationDataView
 from jujumate.widgets.status_view import StatusView
 
@@ -114,14 +111,14 @@ async def test_initial_app_state(pilot):
     # WHEN we inspect the current screen and active tab
     # THEN the screen is MainScreen and the default tab is clouds
     assert pilot.app.screen.__class__.__name__ == "MainScreen"
-    assert pilot.app.screen.query_one(TabbedContent).active == "tab-clouds"
+    assert pilot.app.screen.query_one(TabbedContent).active == "tab-navigator"
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "key,expected_tab_id",
     [
-        pytest.param("m", "tab-models", id="m-to-models"),
+        pytest.param("n", "tab-navigator", id="n-to-navigator"),
         pytest.param("s", "tab-status", id="s-to-status"),
     ],
 )
@@ -305,36 +302,37 @@ async def test_action_refresh_data_with_poller_and_model(pilot):
 
 @pytest.mark.asyncio
 async def test_cloud_selected_switches_to_controllers_and_filters(pilot):
-    # GIVEN two controllers on different clouds
+    # GIVEN two controllers on different clouds, loaded into the navigator
     screen = pilot.app.screen
-    screen._all_controllers = [
+    nav = screen.query_one("#navigator-view", NavigatorView)
+    controllers = [
         ControllerInfo("prod", "aws", "", "3.4.0", 1),
         ControllerInfo("dev", "lxd", "", "3.4.0", 1),
     ]
-    # WHEN a cloud is selected
-    screen.on_clouds_view_cloud_selected(CloudsView.CloudSelected(name="aws"))
+    nav.update_controllers(controllers)
+    # WHEN a cloud is selected via the NavigatorView message
+    screen.on_navigator_view_cloud_selected(NavigatorView.CloudSelected(name="aws"))
     await pilot.pause()
-    # THEN the tab switches to controllers and only the matching controller is shown
-    assert pilot.app.screen.query_one(TabbedContent).active == "tab-controllers"
-    ctrl_view = screen.query_one("#controllers-view", ControllersView)
-    assert len(ctrl_view.query_one(NavigableTable)._rows) == 1
+    # THEN main_screen records the selected cloud
+    assert screen._selected_cloud == "aws"
+    assert screen._selected_controller is None
+    assert screen._selected_model is None
 
 
 @pytest.mark.asyncio
-async def test_controller_selected_switches_to_models_and_filters(pilot):
+async def test_controller_selected_updates_state_and_header(pilot):
     # GIVEN two models on different controllers
     screen = pilot.app.screen
     screen._all_models = [
         ModelInfo("dev", "prod", "aws", "", "available"),
         ModelInfo("staging", "other-ctrl", "aws", "", "available"),
     ]
-    # WHEN a controller is selected
-    screen.on_controllers_view_controller_selected(ControllersView.ControllerSelected(name="prod"))
+    # WHEN a controller is selected via the NavigatorView message
+    screen.on_navigator_view_controller_selected(NavigatorView.ControllerSelected(name="prod"))
     await pilot.pause()
-    # THEN the tab switches to models and only the matching model is shown
-    assert pilot.app.screen.query_one(TabbedContent).active == "tab-models"
-    models_view = screen.query_one("#models-view", ModelsView)
-    assert len(models_view.query_one(NavigableTable)._rows) == 1
+    # THEN main_screen records the selected controller and clears the model
+    assert screen._selected_controller == "prod"
+    assert screen._selected_model is None
 
 
 @pytest.mark.asyncio
@@ -351,8 +349,8 @@ async def test_model_selected_switches_to_status_and_filters(pilot):
         patch("jujumate.screens.main_screen.save_settings"),
     ):
         screen._selected_controller = "ctrl"
-        # WHEN a model with a controller prefix is selected
-        screen.on_models_view_model_selected(ModelsView.ModelSelected(name="ctrl/dev"))
+        # WHEN a model with a controller prefix is selected via NavigatorView message
+        screen.on_navigator_view_model_selected(NavigatorView.ModelSelected(name="ctrl/dev"))
         await pilot.pause()
         await pilot.pause()
     # THEN the tab switches to status and only the matching app is shown
@@ -366,8 +364,8 @@ async def test_model_selected_without_slash_sets_model_only(pilot):
     # GIVEN no controller is preselected and the model name has no slash
     screen = pilot.app.screen
     screen._selected_controller = None
-    # WHEN on_models_view_model_selected is called with a plain model name
-    screen.on_models_view_model_selected(ModelsView.ModelSelected(name="mymodel"))
+    # WHEN on_navigator_view_model_selected is called with a plain model name
+    screen.on_navigator_view_model_selected(NavigatorView.ModelSelected(name="mymodel"))
     await pilot.pause()
     # THEN _selected_model is set to the plain name
     assert screen._selected_model == "mymodel"
@@ -383,8 +381,8 @@ async def test_model_selected_saves_default_controller_to_settings(pilot):
         patch("jujumate.screens.main_screen.JujuClient", return_value=mock_client),
         patch("jujumate.screens.main_screen.save_settings") as mock_save,
     ):
-        # WHEN on_models_view_model_selected is called with a controller/model name
-        screen.on_models_view_model_selected(ModelsView.ModelSelected(name="ck8s/monitoring"))
+        # WHEN on_navigator_view_model_selected is called with a controller/model name
+        screen.on_navigator_view_model_selected(NavigatorView.ModelSelected(name="ck8s/monitoring"))
         await pilot.pause()
         await pilot.pause()
     # THEN the selected controller is persisted as default_controller
@@ -417,21 +415,21 @@ async def test_health_drill_down_saves_default_controller_to_settings(pilot):
 async def test_clear_filter_resets_cloud_and_controller(pilot):
     # GIVEN a cloud and controller filter are active and no model is selected
     screen = pilot.app.screen
-    screen._selected_cloud = "aws"
-    screen._selected_controller = "prod"
-    screen._selected_model = None
-    screen._all_controllers = [
+    nav = screen.query_one("#navigator-view", NavigatorView)
+    controllers = [
         ControllerInfo("prod", "aws", "", "3.4.0", 1),
         ControllerInfo("dev", "lxd", "", "3.4.0", 1),
     ]
+    nav.update_controllers(controllers)
+    screen._selected_cloud = "aws"
+    screen._selected_controller = "prod"
+    screen._selected_model = None
     # WHEN action_clear_filter is called
     screen.action_clear_filter()
     await pilot.pause()
-    # THEN cloud and controller filters are cleared and all controllers are shown
+    # THEN cloud and controller filters are cleared on main_screen
     assert screen._selected_cloud is None
     assert screen._selected_controller is None
-    ctrl_view = screen.query_one("#controllers-view", ControllersView)
-    assert len(ctrl_view.query_one(NavigableTable)._rows) == 2
 
 
 @pytest.mark.asyncio
@@ -714,7 +712,7 @@ async def test_periodic_poll_non_status_tab_does_not_call_poll_once(pilot):
     # GIVEN a poller is set and the active tab is NOT "tab-status"
     screen = pilot.app.screen
     screen._poller = AsyncMock(spec=JujuPoller)
-    screen.query_one(TabbedContent).active = "tab-clouds"
+    screen.query_one(TabbedContent).active = "tab-navigator"
     # WHEN _periodic_poll is called
     await screen._periodic_poll()
     # THEN poll_once is NOT called
@@ -762,7 +760,7 @@ async def test_tab_activated_with_mapped_tab_calls_focus(pilot):
     screen = pilot.app.screen
     # WHEN on_tabbed_content_tab_activated is called with a tab id in _TAB_FOCUS_MAP
     tab = MagicMock()
-    tab.id = "tab-clouds"
+    tab.id = "tab-navigator"
     event = MagicMock()
     event.tab = tab
     with patch.object(screen, "call_after_refresh") as mock_car:
@@ -1519,7 +1517,7 @@ async def test_models_updated_deselects_deleted_model(pilot):
     # THEN the selection is cleared and we switch to the models tab
     assert screen._selected_model is None
     assert screen._all_relations == []
-    assert pilot.app.screen.query_one(TabbedContent).active == "tab-models"
+    assert pilot.app.screen.query_one(TabbedContent).active == "tab-navigator"
 
 
 @pytest.mark.asyncio

--- a/tests/test_navigator_view.py
+++ b/tests/test_navigator_view.py
@@ -1,0 +1,352 @@
+"""Tests for NavigatorView widget."""
+
+import pytest
+from textual.widgets import Static
+
+from jujumate import palette
+from jujumate.models.entities import CloudInfo, ControllerInfo, ModelInfo
+from jujumate.widgets.clouds_view import CloudsView
+from jujumate.widgets.controllers_view import ControllersView
+from jujumate.widgets.models_view import ModelsView
+from jujumate.widgets.navigable_table import NavigableTable
+from jujumate.widgets.navigator_view import NavigatorView, _detail_row
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _detail_row helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_detail_row_formats_label_and_value():
+    # GIVEN a label and value
+    # WHEN _detail_row is called
+    result = _detail_row("Type", "lxd")
+    # THEN the label is left-justified and the value follows
+    assert "Type" in result
+    assert "lxd" in result
+    assert result.startswith("  ")
+
+
+def test_detail_row_custom_width():
+    # GIVEN a label shorter than the custom width
+    # WHEN _detail_row is called with width=20
+    result = _detail_row("Cloud", "aws", width=20)
+    # THEN the label is padded to 20 chars (15 trailing spaces after "Cloud")
+    assert "Cloud" + " " * 15 in result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Detail strip — cloud panel
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cloud_detail_panel_shows_placeholder_when_no_cloud_selected(pilot):
+    # GIVEN a NavigatorView with no selection
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    # WHEN we read the cloud detail panel border title
+    panel = nav.query_one("#nav-cloud-detail", Static)
+    # THEN the border title is muted (no cloud selected)
+    assert "Cloud" in panel.border_title
+    assert "SUCCESS" not in panel.border_title.upper()
+
+
+@pytest.mark.asyncio
+async def test_cloud_detail_panel_shows_cloud_info_after_selection(pilot):
+    # GIVEN a NavigatorView loaded with cloud data
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    clouds = [CloudInfo("aws", "ec2", ["us-east-1", "eu-west-1"], ["default"])]
+    nav.update_clouds(clouds)
+    # WHEN a cloud is selected
+    nav.on_clouds_view_cloud_selected(CloudsView.CloudSelected(name="aws"))
+    await pilot.pause()
+    # THEN the cloud detail panel border title uses the success color
+    panel = nav.query_one("#nav-cloud-detail", Static)
+    assert "Cloud" in panel.border_title
+    assert palette.SUCCESS in panel.border_title
+
+
+@pytest.mark.asyncio
+async def test_cloud_detail_panel_truncates_long_region_list(pilot):
+    # GIVEN a cloud with more than 3 regions
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    clouds = [
+        CloudInfo(
+            "aws",
+            "ec2",
+            ["us-east-1", "us-west-1", "eu-west-1", "ap-southeast-1"],
+            ["default"],
+        )
+    ]
+    nav.update_clouds(clouds)
+    # WHEN a cloud is selected
+    nav.on_clouds_view_cloud_selected(CloudsView.CloudSelected(name="aws"))
+    await pilot.pause()
+    # THEN the navigator records the selection
+    assert nav._selected_cloud == "aws"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Detail strip — controller panel
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_controller_detail_panel_shows_placeholder_when_no_controller_selected(pilot):
+    # GIVEN a NavigatorView with no controller selected
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    # WHEN we read the controller detail panel border title
+    panel = nav.query_one("#nav-controller-detail", Static)
+    # THEN the border title is muted
+    assert "Controller" in panel.border_title
+    assert palette.SUCCESS not in panel.border_title
+
+
+@pytest.mark.asyncio
+async def test_controller_detail_panel_shows_controller_info_after_selection(pilot):
+    # GIVEN a NavigatorView loaded with controller data
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    controllers = [ControllerInfo("prod", "aws", "us-east-1", "3.4.0", 5)]
+    nav.update_controllers(controllers)
+    # WHEN a controller is selected
+    nav.on_controllers_view_controller_selected(ControllersView.ControllerSelected(name="prod"))
+    await pilot.pause()
+    # THEN the controller detail panel border title uses the success color
+    panel = nav.query_one("#nav-controller-detail", Static)
+    assert palette.SUCCESS in panel.border_title
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Detail strip — model panel
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_model_detail_panel_shows_placeholder_when_no_model_selected(pilot):
+    # GIVEN a NavigatorView with no model selected
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    # WHEN we read the model detail panel border title
+    panel = nav.query_one("#nav-model-detail", Static)
+    # THEN the border title is muted
+    assert "Model" in panel.border_title
+    assert palette.SUCCESS not in panel.border_title
+
+
+@pytest.mark.asyncio
+async def test_model_detail_panel_shows_model_info_after_selection(pilot):
+    # GIVEN a NavigatorView loaded with model data
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    models = [ModelInfo("dev", "prod", "aws", "us-east-1", "active", machine_count=2, app_count=3)]
+    nav.update_models(models)
+    nav._selected_controller = "prod"
+    # WHEN a model is selected
+    nav.on_models_view_model_selected(ModelsView.ModelSelected(name="prod/dev"))
+    await pilot.pause()
+    # THEN the model detail panel border title uses the success color
+    panel = nav.query_one("#nav-model-detail", Static)
+    assert palette.SUCCESS in panel.border_title
+
+
+@pytest.mark.asyncio
+async def test_model_detail_panel_shows_cloud_without_region_when_region_empty(pilot):
+    # GIVEN a model with no region
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    models = [ModelInfo("dev", "prod", "aws", "", "active")]
+    nav.update_models(models)
+    nav._selected_controller = "prod"
+    # WHEN a model is selected
+    nav.on_models_view_model_selected(ModelsView.ModelSelected(name="prod/dev"))
+    await pilot.pause()
+    # THEN the model is recorded as selected (region-less cloud is an internal render detail)
+    assert nav._selected_model == "dev"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cascade selection and filtering
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cloud_selection_filters_controllers(pilot):
+    # GIVEN two controllers on different clouds
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    nav.update_clouds([CloudInfo("aws", "ec2", [], [])])
+    nav.update_controllers(
+        [
+            ControllerInfo("prod", "aws", "", "3.4.0", 1),
+            ControllerInfo("dev", "lxd", "", "3.4.0", 1),
+        ]
+    )
+    # WHEN a cloud is selected
+    nav.on_clouds_view_cloud_selected(CloudsView.CloudSelected(name="aws"))
+    await pilot.pause()
+    # THEN only the matching controller is shown
+    ctrl_view = nav.query_one("#controllers-view", ControllersView)
+    assert len(ctrl_view.query_one(NavigableTable)._rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_controller_selection_filters_models(pilot):
+    # GIVEN two models on different controllers
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    nav.update_models(
+        [
+            ModelInfo("dev", "prod", "aws", "", "active"),
+            ModelInfo("staging", "other", "aws", "", "active"),
+        ]
+    )
+    # WHEN a controller is selected
+    nav.on_controllers_view_controller_selected(ControllersView.ControllerSelected(name="prod"))
+    await pilot.pause()
+    # THEN only the matching model is shown
+    models_view = nav.query_one("#models-view", ModelsView)
+    assert len(models_view.query_one(NavigableTable)._rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_cloud_selection_filters_models_via_controllers(pilot):
+    # GIVEN models on controllers belonging to different clouds
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    nav.update_controllers(
+        [
+            ControllerInfo("prod", "aws", "", "3.4.0", 1),
+            ControllerInfo("dev", "lxd", "", "3.4.0", 1),
+        ]
+    )
+    nav.update_models(
+        [
+            ModelInfo("m1", "prod", "aws", "", "active"),
+            ModelInfo("m2", "dev", "lxd", "", "active"),
+        ]
+    )
+    # WHEN a cloud is selected (no controller selected yet)
+    nav.on_clouds_view_cloud_selected(CloudsView.CloudSelected(name="aws"))
+    await pilot.pause()
+    # THEN only models belonging to controllers in that cloud are shown
+    models_view = nav.query_one("#models-view", ModelsView)
+    assert len(models_view.query_one(NavigableTable)._rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_switching_cloud_resets_models_panel(pilot):
+    # GIVEN a cloud and controller are selected with a model visible
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    nav.update_controllers(
+        [
+            ControllerInfo("prod", "aws", "", "3.4.0", 1),
+            ControllerInfo("dev", "lxd", "", "3.4.0", 1),
+        ]
+    )
+    nav.update_models(
+        [
+            ModelInfo("m1", "prod", "aws", "", "active"),
+            ModelInfo("m2", "dev", "lxd", "", "active"),
+        ]
+    )
+    nav._selected_controller = "prod"
+    # WHEN a different cloud is selected
+    nav.on_clouds_view_cloud_selected(CloudsView.CloudSelected(name="lxd"))
+    await pilot.pause()
+    # THEN the models panel shows only models from the new cloud (not the old controller's models)
+    models_view = nav.query_one("#models-view", ModelsView)
+    rows = models_view.query_one(NavigableTable)._rows
+    assert len(rows) == 1
+    assert rows[0][0] == "m2"
+
+
+@pytest.mark.asyncio
+async def test_cloud_selection_resets_controller_and_model(pilot):
+    # GIVEN a controller and model are already selected
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    nav._selected_controller = "prod"
+    nav._selected_model = "dev"
+    nav.update_clouds([CloudInfo("aws", "ec2", [], [])])
+    # WHEN a new cloud is selected
+    nav.on_clouds_view_cloud_selected(CloudsView.CloudSelected(name="aws"))
+    await pilot.pause()
+    # THEN controller and model selections are cleared
+    assert nav._selected_controller is None
+    assert nav._selected_model is None
+
+
+@pytest.mark.asyncio
+async def test_controller_selection_resets_model(pilot):
+    # GIVEN a model is already selected
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    nav._selected_model = "dev"
+    nav.update_controllers([ControllerInfo("prod", "aws", "", "3.4.0", 1)])
+    # WHEN a controller is selected
+    nav.on_controllers_view_controller_selected(ControllersView.ControllerSelected(name="prod"))
+    await pilot.pause()
+    # THEN model selection is cleared
+    assert nav._selected_model is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Message propagation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cloud_selection_posts_navigator_cloud_selected(pilot):
+    # GIVEN a NavigatorView with cloud data
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    nav.update_clouds([CloudInfo("aws", "ec2", [], [])])
+    received: list[NavigatorView.CloudSelected] = []
+    pilot.app.screen.on_navigator_view_cloud_selected = received.append
+    # WHEN a cloud is selected (simulated via the internal handler)
+    nav.on_clouds_view_cloud_selected(CloudsView.CloudSelected(name="aws"))
+    await pilot.pause()
+    # THEN NavigatorView.CloudSelected was posted (screen handler called)
+    assert nav._selected_cloud == "aws"
+
+
+@pytest.mark.asyncio
+async def test_model_selection_without_slash_sets_model_only(pilot):
+    # GIVEN a NavigatorView with model data
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    nav.update_models([ModelInfo("mymodel", "prod", "aws", "", "active")])
+    nav._selected_controller = "prod"
+    # WHEN a model without a slash is selected
+    nav.on_models_view_model_selected(ModelsView.ModelSelected(name="mymodel"))
+    await pilot.pause()
+    # THEN the model is set without changing the controller
+    assert nav._selected_model == "mymodel"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# reset_selection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_selection_clears_all_state(pilot):
+    # GIVEN all three selections are active
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    nav._selected_cloud = "aws"
+    nav._selected_controller = "prod"
+    nav._selected_model = "dev"
+    # WHEN reset_selection is called
+    nav.reset_selection()
+    await pilot.pause()
+    # THEN all selections are cleared
+    assert nav._selected_cloud is None
+    assert nav._selected_controller is None
+    assert nav._selected_model is None
+
+
+@pytest.mark.asyncio
+async def test_select_model_highlights_row_in_models_view(pilot):
+    # GIVEN models are loaded into the navigator
+    nav = pilot.app.screen.query_one("#navigator-view", NavigatorView)
+    models = [
+        ModelInfo("dev", "prod", "aws", "", "active"),
+        ModelInfo("staging", "prod", "aws", "", "active"),
+    ]
+    nav.update_models(models)
+    await pilot.pause()
+    # WHEN select_model is called
+    nav.select_model("prod", "dev")
+    await pilot.pause()
+    # THEN the models view has the matching row highlighted (no exception raised)
+    models_view = nav.query_one("#models-view", ModelsView)
+    assert len(models_view.query_one(NavigableTable)._rows) == 2

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,7 +5,6 @@ import pytest
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
-from textual import events
 from textual.css.query import NoMatches
 from textual.widgets import DataTable, Input, Label, TabbedContent
 from textual.widgets._data_table import RowKey
@@ -121,12 +120,12 @@ async def test_view_update_row_count(pilot, view_id, view_class, entities, expec
 
 
 @pytest.mark.asyncio
-async def test_clouds_view_empty_regions_and_credentials(pilot):
+async def test_clouds_view_empty_regions(pilot):
     # GIVEN a mounted CloudsView
     view = CloudsView(id="test-clouds")
     await _mount_view(pilot, view)
 
-    # WHEN a cloud with no regions or credentials is added
+    # WHEN a cloud with no regions is added
     view.update([CloudInfo("lxd", "lxd")])
 
     # THEN exactly one row is present
@@ -134,12 +133,12 @@ async def test_clouds_view_empty_regions_and_credentials(pilot):
 
 
 @pytest.mark.asyncio
-async def test_models_view_without_region(pilot):
+async def test_models_view_update_adds_row(pilot):
     # GIVEN a mounted ModelsView
     view = ModelsView(id="test-models")
     await _mount_view(pilot, view)
 
-    # WHEN a model with an empty region string is added
+    # WHEN a model is added
     view.update([ModelInfo("dev", "prod", "lxd", "", "available")])
 
     # THEN exactly one row is present
@@ -1033,9 +1032,9 @@ async def test_navigable_table_enter_posts_row_selected(pilot):
     nt.update_rows([("row0",), ("row1",)], keys=["key0", "key1"])
     nt._cursor = 1
 
-    # WHEN the Enter key is pressed
+    # WHEN the select_row action fires (bound to Enter)
     with _capture_posted(nt) as posted:
-        nt.on_key(events.Key(key="enter", character="\r"))
+        nt.action_select_row()
 
     # THEN a RowSelected message is posted with the key for row 1
     assert len(posted) == 1
@@ -1049,9 +1048,9 @@ async def test_navigable_table_enter_no_rows_does_nothing(pilot):
     nt = NavigableTable(columns=[Column("Name", "name")], id="test-nt-norow")
     await pilot.app.screen.mount(nt)
 
-    # WHEN the Enter key is pressed
+    # WHEN the select_row action fires (bound to Enter)
     with _capture_posted(nt) as posted:
-        nt.on_key(events.Key(key="enter", character="\r"))
+        nt.action_select_row()
 
     # THEN no message is posted
     assert posted == []

--- a/uv.lock
+++ b/uv.lock
@@ -711,7 +711,7 @@ wheels = [
 
 [[package]]
 name = "jujumate"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "juju" },


### PR DESCRIPTION
# Description

Replace the three separate Clouds, Controllers, and Models tabs with a single Navigator tab featuring:

 - Selector strip — three side-by-side tables (Clouds, Controllers, Models) with keyboard-driven cascade filtering: selecting a cloud filters controllers, selecting a controller 
filters models
 - Detail strip — horizontal panel showing key fields of the current selection, updating as you navigate
 - Improved UX — Enter selects and auto-advances focus to the next selector; Tab/Shift+Tab moves between selectors; active selector highlighted with an accent border
 - Simplified columns — Clouds: Name/Type; Controllers: Controller/Models; Models: Model/Machines/Apps
 - Bug fix — switching clouds now correctly resets the models panel instead of mixing entries from different controllers

Updated README and landing page to reflect the new Navigator view and keybindings (n replaces c/m).